### PR TITLE
Add README community and contributor sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,29 @@ node scripts/validate-catalog.mjs
 
 The build records every Engine source dependency needed by a package under `sources/engine`, so future catalog builds do not depend on those implementations remaining in the base Engine.
 
+---
+
+## Community & Support
+
+- [**Join our Discord**](https://discord.com/invite/KdAkTg94ME) — Chat, get help, share characters, and give feedback
+- [**Support on Ko-fi**](https://ko-fi.com/marinara_spaghetti) — Help keep the project alive
+
+---
+
+## Contributors
+
+<p align="left">
+  <a href="https://github.com/Pasta-Devs/Marinara-Agents/graphs/contributors">
+    <img src="https://contrib.rocks/image?repo=Pasta-Devs/Marinara-Agents" alt="Marinara Agents contributors" />
+  </a>
+</p>
+
+<p align="left">
+  Made with <a href="https://contrib.rocks">contrib.rocks</a>.
+</p>
+
+---
+
 ## License
 
-Marinara Agents is released under the [GNU Affero General Public License v3.0](LICENSE).
+[AGPL-3.0](LICENSE)


### PR DESCRIPTION
## Why

Marinara Agents did not expose the shared community and support channels or visibly credit repository contributors in the same way as the main Marinara Engine repository.

## Changes

- add the shared Discord and Ko-fi links under **Community & Support**;
- add a contrib.rocks-backed **Contributors** section for `Pasta-Devs/Marinara-Agents`;
- align the **License** section with Marinara Engine's concise AGPL-3.0 presentation.

## Impact

Documentation only. Package payloads, manifests, generated artifacts, catalog metadata, permissions, and runtime behavior are unchanged.

## Validation

- `node scripts/validate-catalog.mjs` — `Catalog valid: 29 packages (21 agents, 8 features).`
- `git diff --check`

Closes #5
