### PR TITLE
feat: add Noodle Posting package

### DIFF
--- a/packages/noodle-posting/agents.json
+++ b/packages/noodle-posting/agents.json
@@ -1,0 +1,21 @@
+[
+  {
+    "id": "noodle-posting",
+    "name": "Noodle Posting",
+    "description": "Lets characters publish Noodle and NoodleR posts when enabled for a chat.",
+    "author": "Pasta Devs",
+    "phase": "pre_generation",
+    "enabledByDefault": false,
+    "category": "misc",
+    "runtimeDisabled": true,
+    "modeAllowlist": [
+      "conversation",
+      "roleplay",
+      "visual_novel"
+    ],
+    "defaultTools": [],
+    "defaultSettings": {},
+    "defaultPromptTemplate": "",
+    "execution": "feature"
+  }
+]

--- a/packages/noodle-posting/manifest.json
+++ b/packages/noodle-posting/manifest.json
@@ -1,0 +1,26 @@
+{
+  "schemaVersion": 1,
+  "id": "noodle-posting",
+  "name": "Noodle Posting",
+  "version": "0.1.0",
+  "description": "Lets characters publish Noodle and NoodleR posts when enabled for a chat.",
+  "engine": {
+    "min": "2.3.0",
+    "maxExclusive": "3.0.0"
+  },
+  "kind": [
+    "agent"
+  ],
+  "entrypoints": {
+    "agents": "agents.json"
+  },
+  "files": [
+    {
+      "path": "agents.json",
+      "sha256": "3c2aebcd699b6460b0b3d45bde6579c84c82ec9120d6ca46ced666d9ec9618fb",
+      "bytes": 511
+    }
+  ],
+  "permissions": [],
+  "restartRequired": true
+}


### PR DESCRIPTION
$## Linked issue\n\nCloses #17\n\n## Dependency\n\nDepends on Pasta-Devs/Marinara-Engine#3618. This draft must not be marked ready or completed until the Engine runtime contract and integration points are finalized.\n\n## Why this change\n\nNoodle character posting changes prompt content and character behavior, so it should use the established installable package and per-chat Agent lifecycle instead of an independent metadata toggle. This keeps Noodle and NoodleR infrastructure in Marinara Engine while making character posting an explicit optional capability.\n\n## What changed\n\n- Added the initial `noodle-posting` package manifest and matching disabled feature Agent definition.\n- Declared Conversation, Roleplay, and Visual Novel support.\n- Deferred executable entrypoints, generated artifacts, catalog publication, artwork, and documentation until Engine PR #3618 finalizes the package runtime contract.\n\n## Validation\n\n- `node scripts/validate-catalog.mjs` (passes: 29 existing catalog packages)\n- `git diff --check`\n- Verified the declared `agents.json` byte size and SHA-256 against the package manifest.\n\n- [ ] Installed or updated the package through Agents -> Download Agents\n- [ ] Verified Conversation `/noodle` and `/noodler` actions\n- [ ] Verified hidden `noodle_post` execution in supported chat modes\n- [ ] Verified package restart and offline restart behavior\n- [ ] Verified uninstall cleanup\n\n## Current proof gaps\n\nThe package is not downloadable or executable in this initial ownership draft. Manual Engine validation cannot begin until Pasta-Devs/Marinara-Engine#3618 exposes and stabilizes the package integration points. No Engine repository files were changed as part of this PR.