### PR TITLE
Fix Conversation Calls file-native storage compatibility

### DIFF
--- a/scripts/build-feature-packages.mjs
+++ b/scripts/build-feature-packages.mjs
@@ -55,7 +55,7 @@ const features = [
   {
     id: "conversation-calls",
     name: "Conversation Calls",
-    version: "1.0.1",
+    version: "1.0.2",
     description: "Adds live audio and video calls with Conversation characters.",
     kind: ["agent", "conversation-calls"],
     modes: ["conversation"],
@@ -130,13 +130,20 @@ export async function selfCheck() {
       ? `import { ${feature.serverExport} as register } from ${JSON.stringify(target)};
 import * as commandRuntime from ${JSON.stringify(resolve(sourceRoot, "packages/server/src/services/generation/conversation-call-command-runtime.ts"))};
 import * as characterVideos from ${JSON.stringify(resolve(sourceRoot, "packages/server/src/services/conversation/call-character-videos.service.ts"))};
+import { createConversationCallsStorage } from ${JSON.stringify(resolve(sourceRoot, "packages/server/src/services/storage/conversation-calls.storage.ts"))};
+let readinessStorage = null;
 export async function activate({ app, api }) {
   await app.register(register, { prefix: ${JSON.stringify(feature.prefix)} });
+  readinessStorage = createConversationCallsStorage(app.db);
   const cleanups = [
     api.registerService("conversation-calls:command", commandRuntime),
     api.registerService("conversation-calls:character-videos", characterVideos),
   ];
-  return () => { for (const cleanup of cleanups.reverse()) cleanup(); };
+  return () => { readinessStorage = null; for (const cleanup of cleanups.reverse()) cleanup(); };
+}
+export async function selfCheck() {
+  if (!readinessStorage) throw new Error("Conversation Calls storage did not initialize");
+  await readinessStorage.getActiveForChat("__marinara_capability_self_check__");
 }\n`
       : feature.serverImport
       ? `import { ${feature.serverExport} as register } from ${JSON.stringify(target)};\nexport async function activate({ app }) { await app.register(register, { prefix: ${JSON.stringify(feature.prefix)} }); }\n`

--- a/sources/engine/packages/server/src/services/storage/conversation-calls.storage.ts
+++ b/sources/engine/packages/server/src/services/storage/conversation-calls.storage.ts
@@ -1,7 +1,7 @@
 // ──────────────────────────────────────────────
 // Storage: Conversation Calls
 // ──────────────────────────────────────────────
-import { and, desc, eq, inArray } from "drizzle-orm";
+import { and, desc, eq, inArray } from "../../db/file-query.js";
 import type { DB } from "../../db/connection.js";
 import { conversationCallMessages, conversationCallSessions, conversationCallSounds } from "../../db/schema/index.js";
 import { newId, now } from "../../utils/id-generator.js";


### PR DESCRIPTION
## Linked issue

Closes #21

## Why this change

Conversation Calls 1.0.1 still contains storage inputs from before Marinara Engine completed its file-native transition. Opening a Conversation can therefore pass an incompatible table to Engine storage, fail the active-call status request, and repeatedly spam `Cannot read properties of undefined (reading 'name')`.

## What changed

- Switch the captured Conversation Calls storage query helpers to Engine's file-native query module.
- Add a package activation self-check that queries call storage before the runtime is marked ready.
- Prepare Conversation Calls 1.0.2 so existing 1.0.1 installations receive an update.
- Rebuild the generated server/client payload, manifest, artifact, and catalog entry from source inputs.

## Validation

- [ ] Manually update Conversation Calls 1.0.1 to 1.0.2 through **Agents → Download Agents**, restart, and open a Conversation.
- [ ] Manually verify call start/end, offline restart, and uninstall cleanup.

Automated validation will include:

- `node scripts/build-feature-packages.mjs conversation-calls`
- `node scripts/validate-catalog.mjs`
- Engine-side package activation/self-check against v2.3.0 staging
- `git diff --check`

## Risk

Conversation Calls contains executable client/server payloads and persistent call storage. The package keeps its existing permissions, Engine compatibility range, chat mode, entrypoints, and restart requirement; only the generated patch artifact and storage compatibility path change.
