### PR TITLE
Fix contradictory PR validation checkbox requirement

### DIFF
--- a/.github/workflows/pull-request-triage.yml
+++ b/.github/workflows/pull-request-triage.yml
@@ -101,12 +101,6 @@ jobs:
             failed=1
           fi
 
-          validation_section=$(echo "$PR_BODY" | sed -n '/## Validation/,/^## /p' | head -n -1)
-          if ! echo "$validation_section" | grep -qP '\[x\]'; then
-            echo "::error::No validation checkbox is ticked. Tick only checks you actually performed."
-            failed=1
-          fi
-
           if [ "$failed" -eq 1 ]; then
             exit 1
           fi


### PR DESCRIPTION
## Linked issue

Closes #28

## Why this change

The pull-request template checker requires at least one checked validation box, while the repository's AI-agent policy explicitly prohibits agents from checking human-verification boxes. As a result, otherwise complete PRs fail when they honestly leave manual lifecycle checks unchecked and provide automated evidence in prose.

This is a maintainer-approved `main` hotfix because `pull_request_target` loads its workflow definition from the default branch.

## What changed

- Removed only the rule requiring `[x]` in the `## Validation` section.
- Kept linked-issue enforcement.
- Kept substantive `Why this change` and `What changed` enforcement.
- Left labeling behavior, permissions, event triggers, and concurrency unchanged.

## Package and security impact

- Affected package IDs: none.
- Engine compatibility impact: none.
- New or changed package permissions/entrypoints: none.
- Workflow security: the `pull_request_target` job still does not check out or execute untrusted PR code.
- Restart, storage, update, or uninstall impact: none.

## Validation

Human verification checkboxes are intentionally not marked by this AI-generated PR.

Automated evidence:

- The exact body of PR #26 passes with all manual verification boxes unchecked.
- A representative body without `Closes #<number>`, `Fixes #<number>`, or `Resolves #<number>` still fails.
- A representative body with placeholder-only `What changed` content still fails.
- `node scripts/validate-catalog.mjs` passes: 29 packages (21 agents, 8 features).
- `git diff --check` passes.
- Ruby/Psych parses `.github/workflows/pull-request-triage.yml` successfully.
- The workflow shell was exercised in a Linux container matching the GitHub-hosted runner's Bash/GNU tool behavior.

## Documentation impact

No documentation changes are needed; this changes only CI enforcement behavior.

## Residual verification note

Until this hotfix reaches `main`, the existing default-branch workflow may fail this PR for the exact checkbox rule removed here. That expected bootstrap failure is the subject of #28.
