### PR TITLE
Exclude generated agent definitions from CodeRabbit review

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -9,6 +9,7 @@ reviews:
   review_status: true
   path_filters:
     - "!artifacts/**"
+    - "!packages/**/agents.json"
     - "!packages/**/client.js"
     - "!packages/**/server.mjs"
     - "!sources/engine/**"


### PR DESCRIPTION
## Linked issue

Closes #42

## Why this change

Catalog-wide package metadata changes can exceed CodeRabbit's 50-file limit before it reviews the source and validation logic because generated `agents.json` definitions are still counted. Generated archives and runtime bundles are already excluded for the same reason.

## What changed

- excluded `packages/**/agents.json` from CodeRabbit review scope
- kept manifests, catalog metadata, scripts, validation, and documentation reviewable

## Package and security impact

- Affected package IDs: none
- Engine compatibility impact: none
- New or changed permissions/entrypoints: none
- Restart, storage, update, or uninstall impact: none

## Validation

- [ ] `node scripts/validate-catalog.mjs` passes locally
- [ ] `git diff --check` passes locally
- [ ] Rebuilt every affected manifest, payload, artifact, and catalog entry
- [ ] Installed or updated the affected package through Marinara Engine
- [ ] Checked supported modes, restart behavior, and uninstall cleanup
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `node scripts/validate-catalog.mjs` — Catalog valid: 29 packages (21 agents, 8 features).
- `git diff --check`
- No package outputs changed or required rebuilding.

## Documentation impact

- [ ] No documentation changes needed
- [ ] Updated this README catalog and package guidance
- [ ] Updated linked Marinara Engine documentation

No user-facing documentation changes are needed for review tooling.

## UI evidence (if applicable)

Not applicable.
