### PR TITLE
chore: target pull requests at main

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -26,6 +26,6 @@ reviews:
     auto_incremental_review: true
     auto_pause_after_reviewed_commits: 0
     base_branches:
-      - "staging"
+      - "main"
 chat:
   auto_reply: true

--- a/.github/agents/chai-workflow.md
+++ b/.github/agents/chai-workflow.md
@@ -33,11 +33,11 @@ Follow instructions in this order:
 ## Issue and Pull Request Lane
 
 - Open or link an issue before implementation and make ownership visible.
-- Base work on `staging`; open a draft PR when implementation begins.
+- Base work on `main`; open a draft PR when implementation begins.
 - Mark the PR ready only when it is ready for human and CodeRabbit review.
 - Leave every PR test checkbox unchecked unless a human actually performed that item.
 - Address actionable review feedback, rerun validation after changes, and obtain one approval before merge.
-- Never push directly to `main` or `staging` without explicit maintainer direction.
+- Never push directly to `main` without explicit maintainer direction.
 
 ## Risky Package Work
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-<!-- Target branch: `staging`. Change the base from `main` before submitting unless this is a maintainer-approved mainline hotfix. -->
+<!-- Target branch: `main`. -->
 <!-- Open as a draft while implementation is in progress. Mark Ready for review only after validation and self-review. -->
 
 ## Linked issue

--- a/.github/workflows/issue-status-from-prs.yml
+++ b/.github/workflows/issue-status-from-prs.yml
@@ -3,7 +3,7 @@ name: Issue Status From Pull Requests
 on:
   pull_request_target:
     types: [opened, reopened, edited, synchronize, ready_for_review, closed]
-    branches: [staging]
+    branches: [main]
 
 concurrency:
   group: issue-status-from-pr-${{ github.event.pull_request.number }}
@@ -22,8 +22,7 @@ jobs:
         with:
           script: |
             const labels = {
-              'in-pr': { color: '1d76db', description: 'Has an open pull request targeting staging' },
-              'fixed-in-staging': { color: '0e8a16', description: 'Merged to staging and pending publication on main' },
+              'in-pr': { color: '1d76db', description: 'Has an open pull request targeting main' },
             };
             const owner = context.repo.owner;
             const repo = context.repo.repo;
@@ -70,26 +69,25 @@ jobs:
               }
             }
 
-            async function openStagingPrIssues() {
-              const pulls = await github.paginate(github.rest.pulls.list, { owner, repo, state: 'open', base: 'staging', per_page: 100 });
+            async function openMainPrIssues() {
+              const pulls = await github.paginate(github.rest.pulls.list, { owner, repo, state: 'open', base: 'main', per_page: 100 });
               return new Set(pulls.flatMap((pull) => linkedIssueNumbers(pull.body)));
             }
 
             for (const issueNumber of linkedIssueNumbers(pr.body)) {
               const issue = await github.rest.issues.get({ owner, repo, issue_number: issueNumber }).catch(() => null);
-              if (!issue || issue.data.pull_request || issue.data.state !== 'open') continue;
+              if (!issue || issue.data.pull_request) continue;
               if (pr.state === 'closed') {
-                if (pr.merged) await addLabel(issueNumber, 'fixed-in-staging');
-                const active = await openStagingPrIssues();
+                const active = await openMainPrIssues();
                 if (!active.has(issueNumber)) await removeLabel(issueNumber, 'in-pr');
-              } else {
+              } else if (issue.data.state === 'open') {
                 await addLabel(issueNumber, 'in-pr');
               }
             }
 
             await ensureLabel('in-pr');
-            const active = await openStagingPrIssues();
-            const labeled = await github.paginate(github.rest.issues.listForRepo, { owner, repo, state: 'open', labels: 'in-pr', per_page: 100 });
+            const active = await openMainPrIssues();
+            const labeled = await github.paginate(github.rest.issues.listForRepo, { owner, repo, state: 'all', labels: 'in-pr', per_page: 100 });
             for (const issue of labeled) {
               if (!issue.pull_request && !active.has(issue.number)) await removeLabel(issue.number, 'in-pr');
             }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ This file is a thin maintainer note for contributors using coding agents. Canoni
 
 ## Preferred Workflow
 
-- Start from `staging` and open an issue before implementation.
+- Start from `main` and open an issue before implementation.
 - Open a draft PR when issue work begins so ownership is visible, then mark it ready only after validation and self-review are complete.
 - Run `node scripts/validate-catalog.mjs` as the baseline validation command.
 - Rebuild the affected package and catalog entry whenever source payloads, manifests, Engine snapshots, or generated bundles change.
@@ -27,4 +27,4 @@ This file is a thin maintainer note for contributors using coding agents. Canoni
 
 - Never auto-check validation or test-plan checkboxes. They are a human verification list, not proof.
 - Explain why the package or repository change is needed, not only which files changed.
-- Link the issue, target `staging`, leave drafts unreviewed by CodeRabbit until they are marked ready, and address actionable review feedback before merge.
+- Link the issue, target `main`, leave drafts unreviewed by CodeRabbit until they are marked ready, and address actionable review feedback before merge.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,19 +6,18 @@ Thank you for helping improve the official downloadable packages for [Marinara E
 
 1. Open an issue or check the [issue tracker](https://github.com/Pasta-Devs/Marinara-Agents/issues) before implementing a new package or material behavior change. This lets maintainers agree on scope and prevents duplicate work.
 2. Check for an issue-linked branch, open or draft PR, and visible owner before beginning work.
-3. Base changes on `staging`. The `main` branch is the published catalog consumed by Marinara Engine.
+3. Base changes on `main`, the protected branch containing the published catalog consumed by Marinara Engine.
 
 ## Branches
 
 | Branch | Role |
 | --- | --- |
-| `staging` | Active development. Package, catalog, documentation, and CI pull requests target this branch. |
-| `main` | Published catalog. Updated by maintainers after reviewed staging changes are ready for users. |
+| `main` | Protected development and release branch. Package, catalog, documentation, and CI pull requests target this branch. |
 
-Create a focused feature branch from current staging:
+Create a focused feature branch from current main:
 
 ```bash
-git checkout staging
+git checkout main
 git pull
 git checkout -b feature/short-description
 ```
@@ -86,7 +85,7 @@ Also manually install or update affected packages through **Agents → Download 
 ## Pull Request Expectations
 
 - Link the issue with `Closes #<number>`, `Fixes #<number>`, or `Resolves #<number>`.
-- Target `staging` unless a maintainer explicitly requests a mainline hotfix.
+- Target `main`.
 - Keep the PR focused and explain the user-facing reason for the change.
 - Mark the PR ready for review only after local validation and self-review.
 - Let CodeRabbit review the ready PR and address actionable findings.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Conversation mode's About Me profile and `update_about_me` tool are built into M
 
 ## Contributing
 
-Agent ideas, bugs, documentation corrections, and package improvements are welcome. Read [CONTRIBUTING.md](CONTRIBUTING.md) before starting: contributions begin with an issue, target the `staging` branch, must be marked ready for review, and require an approving review before merge. CodeRabbit automatically reviews ready pull requests.
+Agent ideas, bugs, documentation corrections, and package improvements are welcome. Read [CONTRIBUTING.md](CONTRIBUTING.md) before starting: contributions begin with an issue, target the `main` branch, must be marked ready for review, and require an approving review before merge. CodeRabbit automatically reviews ready pull requests.
 
 ## Maintainer build
 


### PR DESCRIPTION
## Linked issue

Closes #53

## Why this change

The repository already uses `main` as its default and published branch. Keeping a separate `staging` branch adds synchronization work and makes contributors retarget pull requests without providing a useful release boundary.

## What changed

- Base contributor work and pull requests on `main`.
- Run CodeRabbit and linked-issue automation for pull requests targeting `main`.
- Remove the obsolete post-merge `fixed-in-staging` issue state.

## Package and security impact

- Affected package IDs: none
- Engine compatibility impact: none
- New or changed permissions/entrypoints: none
- Restart, storage, update, or uninstall impact: none

## Validation

- [ ] `node scripts/validate-catalog.mjs` passes locally
- [ ] `git diff --check` passes locally
- [ ] Rebuilt every affected manifest, payload, artifact, and catalog entry
- [ ] Installed or updated the affected package through Marinara Engine
- [ ] Checked supported modes, restart behavior, and uninstall cleanup
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `node scripts/validate-catalog.mjs` — `Catalog valid: 29 packages (21 agents, 8 features).`
- `git diff --check` — passed.
- `.coderabbit.yaml` and `.github/workflows/issue-status-from-prs.yml` — parsed successfully as YAML.
- The embedded `actions/github-script` body — passed `node --check` inside an async wrapper matching its execution context.
- No package rebuild or Engine install was needed because this changes repository governance and automation only.

## Documentation impact

- [ ] No documentation changes needed
- [ ] Updated this README catalog and package guidance
- [ ] Updated linked Marinara Engine documentation

Contributor documentation was updated for the main-only workflow. Engine package documentation is unaffected.

## UI evidence (if applicable)

Not applicable.
