### PR TITLE
Harden Agent catalog publishing trust

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,7 @@
 # Agent packages are executable code loaded by Marinara Engine. Keep the
 # publishing pipeline, package payloads, and generated trust metadata under
 # explicit maintainer review.
+/.github/CODEOWNERS @SpicyMarinara
 /.github/workflows/ @SpicyMarinara
 /scripts/ @SpicyMarinara
 /schemas/ @SpicyMarinara

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# Agent packages are executable code loaded by Marinara Engine. Keep the
+# publishing pipeline, package payloads, and generated trust metadata under
+# explicit maintainer review.
+/.github/workflows/ @SpicyMarinara
+/scripts/ @SpicyMarinara
+/schemas/ @SpicyMarinara
+/packages/ @SpicyMarinara
+/sources/ @SpicyMarinara
+/artifacts/ @SpicyMarinara
+/catalog/ @SpicyMarinara

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,6 +120,8 @@ A new package must include:
 
 Security-sensitive permissions and executable client/server entrypoints must be narrowly scoped and justified in the PR description.
 
+Package hashes are integrity checks, not independent publisher signatures. A contributor who can change both an artifact and its catalog entry can also change the recorded hash. For that reason, changes under `packages/`, `sources/`, `artifacts/`, `catalog/`, `scripts/`, or `.github/workflows/` require the code-owner review configured in `.github/CODEOWNERS`. Maintainers must keep **Require review from Code Owners** and stale-approval dismissal enabled for `main`; see [SECURITY.md](SECURITY.md) for the full repository ruleset.
+
 ## AI Agent Workflow
 
 Coding agents use `.github/agents/chai-workflow.md` as an additive proof and coordination layer. `CONTRIBUTING.md`, `AGENTS.md`, package contracts, and the maintainer's latest request take priority.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Do not open a public issue for a vulnerability that could expose user data or execute code. Use the repository's **Security** tab to submit a private vulnerability report. Include the affected package or publishing path, the Engine version, reproduction steps, and the impact.
+
+## Package trust model
+
+Marinara Agent packages may contain server and client entrypoints. Server entrypoints run inside the Marinara Engine process; manifest permissions describe intended access but are not an operating-system sandbox. Treat every package, artifact, catalog entry, build script, and publishing workflow as executable supply-chain material.
+
+Catalog SHA-256 values detect accidental corruption and mismatched downloads. They do not protect against an attacker who can change both an artifact and its catalog hash. The repository therefore also:
+
+- requires canonical same-repository artifact URLs during catalog validation;
+- maps security-sensitive paths to a maintainer in `CODEOWNERS`;
+- validates source manifests, archive contents, file hashes, catalog lanes, and generated outputs in pull requests; and
+- pins third-party GitHub Actions by full commit SHA.
+
+Repository administrators should keep `main` protected with pull requests required, Code Owner review required, stale approvals dismissed after new commits, the catalog validation check required, force pushes and branch deletion disabled, and administrator bypass restricted. `CODEOWNERS` requests review, but GitHub enforces it only when the matching branch-protection or ruleset option is enabled.

--- a/scripts/validate-catalog.mjs
+++ b/scripts/validate-catalog.mjs
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
 import { readFile, readdir } from "node:fs/promises";
-import { basename, dirname, extname, join, resolve } from "node:path";
+import { dirname, extname, join, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 import { pathToFileURL } from "node:url";
 import {
@@ -246,6 +246,12 @@ for (const entry of catalog.packages) {
   if (iconUrl !== catalogArtworkUrl(manifest.id)) {
     throw new Error(`Missing or invalid catalog artwork URL for ${manifest.id}`);
   }
+  const expectedArtifactName = `${manifest.id}-${manifest.version}.zip`;
+  const expectedArtifactUrl =
+    `https://raw.githubusercontent.com/Pasta-Devs/Marinara-Agents/main/artifacts/${expectedArtifactName}`;
+  if (artifact.url !== expectedArtifactUrl) {
+    throw new Error(`Artifact URL for ${manifest.id} must be ${expectedArtifactUrl}`);
+  }
   const artworkPath = join(repoRoot, catalogArtworkRelativePath(manifest.id));
   const artwork = await readFile(artworkPath);
   const pngSignature = artwork.subarray(0, 8).toString("hex");
@@ -264,7 +270,7 @@ for (const entry of catalog.packages) {
   if (JSON.stringify(sourceManifest) !== JSON.stringify(manifest)) {
     throw new Error(`Catalog manifest does not match packages/${manifest.id}/manifest.json`);
   }
-  const artifactPath = join(repoRoot, "artifacts", basename(new URL(artifact.url).pathname));
+  const artifactPath = join(repoRoot, "artifacts", expectedArtifactName);
   const archive = await readFile(artifactPath);
   if (archive.byteLength !== artifact.bytes) throw new Error(`Artifact size mismatch for ${manifest.id}`);
   if (createHash("sha256").update(archive).digest("hex") !== artifact.sha256) {


### PR DESCRIPTION
## Linked issue

None. This is maintainer-requested security hardening; no public issue was opened before the controls were ready for review.

## Why this change

Catalog SHA-256 values prove that a download matches the catalog, but not that a catalog author is trustworthy: anyone able to change both the artifact and its adjacent hash could publish new executable client/server code. The repository therefore needs stronger review boundaries and canonical publication invariants.

## What changed

- Added CODEOWNERS coverage for workflows, build/validation scripts, schemas, packages, Engine source snapshots, artifacts, and catalogs.
- Added `SECURITY.md` documenting private vulnerability reporting, the executable package trust model, hash limitations, and required repository rules.
- Made catalog validation reject artifact URLs that do not exactly match `https://raw.githubusercontent.com/Pasta-Devs/Marinara-Agents/main/artifacts/<id>-<version>.zip`.
- Updated contributor guidance to require code-owner review for supply-chain-sensitive paths.

## Package and security impact

- Affected package IDs: none; all 29 current packages retain identical manifests and artifacts.
- Engine compatibility impact: none.
- New or changed permissions/entrypoints: none.
- Restart, storage, update, or uninstall impact: none.
- Publishing impact: official catalog entries can no longer redirect executable downloads to another host or filename while passing local validation.
- Administrator follow-up: `main` is currently unprotected. CODEOWNERS becomes enforceable only after GitHub branch protection/rulesets require Code Owner review, dismiss stale approvals, require catalog validation, and disallow force pushes/deletion.

## Validation

- [ ] `node scripts/test-catalog-lanes.mjs` passes locally
- [ ] `node scripts/validate-catalog.mjs` passes locally
- [ ] `git diff --check` passes locally
- [ ] Confirm the GitHub ruleset requires Code Owner review for `main`
- [ ] Confirm stale approvals are dismissed after new commits
- [ ] Confirm the catalog validation check is required

### Automated evidence

- `node scripts/test-catalog-lanes.mjs` passed.
- `node scripts/validate-catalog.mjs` passed: 29 packages (21 agents, 8 features), v2=29, v3=6, legacy=v2.
- `git diff --check` passed.

### Manual verification notes

- [ ] Manually verify a PR changing `catalog/`, `artifacts/`, or `scripts/` requests `@SpicyMarinara` as code owner after branch protection is enabled.
- [ ] Manually verify a non-canonical artifact URL fails the pull-request catalog validation workflow.

## Documentation impact

- [ ] Review the new private-reporting guidance in `SECURITY.md`.
- [ ] Review the contributor trust-model note in `CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added security guidance for privately reporting vulnerabilities and understanding package, artifact, and catalog trust boundaries.
  - Clarified contribution requirements, integrity checks, code-owner review, and branch-protection expectations.

- **Chores**
  - Added repository ownership rules for sensitive directories and workflow changes.

- **Bug Fixes**
  - Improved catalog validation by consistently deriving artifact URLs and filenames from package identity and version information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->