### PR TITLE
Restore staging-first Agent publishing governance

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -19,13 +19,14 @@ reviews:
     - path: "scripts/**"
       instructions: "Treat package construction, archive paths, catalog integrity, checksums, and generated payload handling as security-sensitive."
     - path: "catalog/catalog.json"
-      instructions: "Verify catalog entries match package manifests and artifacts, and that published raw URLs target the main branch."
+      instructions: "Verify catalog entries match package manifests and artifacts. Canonical catalog URLs remain on main; Engine staging securely maps official artifacts to this repository's staging branch for testing."
   auto_review:
     enabled: true
     drafts: false
     auto_incremental_review: true
     auto_pause_after_reviewed_commits: 0
     base_branches:
+      - "staging"
       - "main"
 chat:
   auto_reply: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -20,6 +20,8 @@ reviews:
       instructions: "Treat package construction, archive paths, catalog integrity, checksums, and generated payload handling as security-sensitive."
     - path: "catalog/catalog.json"
       instructions: "Verify catalog entries match package manifests and artifacts. Canonical catalog URLs remain on main; Engine staging securely maps official artifacts to this repository's staging branch for testing."
+    - path: "catalog/v*/catalog.json"
+      instructions: "Verify every Engine-major catalog lane matches package manifests and artifacts. Canonical catalog URLs remain on main; Engine staging securely maps official artifacts to this repository's staging branch for testing."
   auto_review:
     enabled: true
     drafts: false

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,11 @@
 # Agent packages are executable code loaded by Marinara Engine. Keep the
 # publishing pipeline, package payloads, and generated trust metadata under
 # explicit maintainer review.
-/.github/CODEOWNERS @SpicyMarinara
-/.github/workflows/ @SpicyMarinara
-/scripts/ @SpicyMarinara
-/schemas/ @SpicyMarinara
-/packages/ @SpicyMarinara
-/sources/ @SpicyMarinara
-/artifacts/ @SpicyMarinara
-/catalog/ @SpicyMarinara
+/.github/CODEOWNERS @Pasta-Devs/developers
+/.github/workflows/ @Pasta-Devs/developers
+/scripts/ @Pasta-Devs/developers
+/schemas/ @Pasta-Devs/developers
+/packages/ @Pasta-Devs/developers
+/sources/ @Pasta-Devs/developers
+/artifacts/ @Pasta-Devs/developers
+/catalog/ @Pasta-Devs/developers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,7 @@
 # Agent packages are executable code loaded by Marinara Engine. Keep the
 # publishing pipeline, package payloads, and generated trust metadata under
 # explicit maintainer review.
+* @Pasta-Devs/developers
 /.github/CODEOWNERS @Pasta-Devs/developers
 /.github/workflows/ @Pasta-Devs/developers
 /scripts/ @Pasta-Devs/developers

--- a/.github/agents/chai-workflow.md
+++ b/.github/agents/chai-workflow.md
@@ -33,10 +33,11 @@ Follow instructions in this order:
 ## Issue and Pull Request Lane
 
 - Open or link an issue before implementation and make ownership visible.
-- Base work on `main`; open a draft PR when implementation begins.
+- Base work on `staging`; open a draft PR targeting `staging` when implementation begins.
 - Mark the PR ready only when it is ready for human and CodeRabbit review.
 - Leave every PR test checkbox unchecked unless a human actually performed that item.
-- Address actionable review feedback, rerun validation after changes, and obtain one approval before merge.
+- Address actionable review feedback and rerun validation after changes. Pasta-Devs developers may merge after required checks and CodeRabbit complete; outside and first-time contributors also need a developer approval.
+- Only `SpicyMarinara` may promote tested `staging` work into `main`.
 - Never push directly to `main` without explicit maintainer direction.
 
 ## Risky Package Work

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
-<!-- Target branch: `staging`. This is the only contribution branch. -->
-<!-- Only SpicyMarinara may open or merge release-promotion PRs to `main`. -->
+> [!IMPORTANT]
+> Contributions target `staging`. Only `SpicyMarinara` may open or merge release-promotion PRs to `main`.
 <!-- Open as a draft while implementation is in progress. Mark Ready for review only after validation and self-review. -->
 
 ## Linked issue

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,5 @@
-<!-- Target branch: `main`. -->
+<!-- Target branch: `staging`. This is the only contribution branch. -->
+<!-- Only SpicyMarinara may open or merge release-promotion PRs to `main`. -->
 <!-- Open as a draft while implementation is in progress. Mark Ready for review only after validation and self-review. -->
 
 ## Linked issue

--- a/.github/workflows/issue-status-from-prs.yml
+++ b/.github/workflows/issue-status-from-prs.yml
@@ -3,7 +3,7 @@ name: Issue Status From Pull Requests
 on:
   pull_request_target:
     types: [opened, reopened, edited, synchronize, ready_for_review, closed]
-    branches: [main]
+    branches: [staging]
 
 concurrency:
   group: issue-status-from-pr-${{ github.event.pull_request.number }}
@@ -22,7 +22,11 @@ jobs:
         with:
           script: |
             const labels = {
-              'in-pr': { color: '1d76db', description: 'Has an open pull request targeting main' },
+              'in-pr': { color: '1d76db', description: 'Has an open pull request targeting staging' },
+              'fixed-in-staging': {
+                color: '0e8a16',
+                description: 'Already fixed in staging and is pending closure when staging is promoted to main',
+              },
             };
             const owner = context.repo.owner;
             const repo = context.repo.repo;
@@ -69,8 +73,8 @@ jobs:
               }
             }
 
-            async function openMainPrIssues() {
-              const pulls = await github.paginate(github.rest.pulls.list, { owner, repo, state: 'open', base: 'main', per_page: 100 });
+            async function openStagingPrIssues() {
+              const pulls = await github.paginate(github.rest.pulls.list, { owner, repo, state: 'open', base: 'staging', per_page: 100 });
               return new Set(pulls.flatMap((pull) => linkedIssueNumbers(pull.body)));
             }
 
@@ -78,7 +82,10 @@ jobs:
               const issue = await github.rest.issues.get({ owner, repo, issue_number: issueNumber }).catch(() => null);
               if (!issue || issue.data.pull_request) continue;
               if (pr.state === 'closed') {
-                const active = await openMainPrIssues();
+                if (pr.merged && issue.data.state === 'open') {
+                  await addLabel(issueNumber, 'fixed-in-staging');
+                }
+                const active = await openStagingPrIssues();
                 if (!active.has(issueNumber)) await removeLabel(issueNumber, 'in-pr');
               } else if (issue.data.state === 'open') {
                 await addLabel(issueNumber, 'in-pr');
@@ -86,7 +93,8 @@ jobs:
             }
 
             await ensureLabel('in-pr');
-            const active = await openMainPrIssues();
+            await ensureLabel('fixed-in-staging');
+            const active = await openStagingPrIssues();
             const labeled = await github.paginate(github.rest.issues.listForRepo, { owner, repo, state: 'all', labels: 'in-pr', per_page: 100 });
             for (const issue of labeled) {
               if (!issue.pull_request && !active.has(issue.number)) await removeLabel(issue.number, 'in-pr');

--- a/.github/workflows/issue-status-from-prs.yml
+++ b/.github/workflows/issue-status-from-prs.yml
@@ -3,7 +3,7 @@ name: Issue Status From Pull Requests
 on:
   pull_request_target:
     types: [opened, reopened, edited, synchronize, ready_for_review, closed]
-    branches: [staging]
+    branches: [staging, main]
 
 concurrency:
   group: issue-status-from-pr-${{ github.event.pull_request.number }}
@@ -31,6 +31,8 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const pr = context.payload.pull_request;
+            const targetsStaging = pr.base?.ref === 'staging';
+            const targetsMain = pr.base?.ref === 'main';
 
             function linkedIssueNumbers(body) {
               const numbers = new Set();
@@ -78,15 +80,30 @@ jobs:
               return new Set(pulls.flatMap((pull) => linkedIssueNumbers(pull.body)));
             }
 
+            const activeStagingPrIssues = await openStagingPrIssues();
+
             for (const issueNumber of linkedIssueNumbers(pr.body)) {
-              const issue = await github.rest.issues.get({ owner, repo, issue_number: issueNumber }).catch(() => null);
+              const issue = await github.rest.issues.get({ owner, repo, issue_number: issueNumber }).catch((error) => {
+                if (error.status === 404) return null;
+                throw error;
+              });
               if (!issue || issue.data.pull_request) continue;
+
+              if (targetsMain) {
+                if (pr.state === 'closed' && pr.merged) {
+                  await removeLabel(issueNumber, 'fixed-in-staging');
+                  await removeLabel(issueNumber, 'in-pr');
+                }
+                continue;
+              }
+
+              if (!targetsStaging) continue;
+
               if (pr.state === 'closed') {
                 if (pr.merged && issue.data.state === 'open') {
                   await addLabel(issueNumber, 'fixed-in-staging');
                 }
-                const active = await openStagingPrIssues();
-                if (!active.has(issueNumber)) await removeLabel(issueNumber, 'in-pr');
+                if (!activeStagingPrIssues.has(issueNumber)) await removeLabel(issueNumber, 'in-pr');
               } else if (issue.data.state === 'open') {
                 await addLabel(issueNumber, 'in-pr');
               }
@@ -94,8 +111,7 @@ jobs:
 
             await ensureLabel('in-pr');
             await ensureLabel('fixed-in-staging');
-            const active = await openStagingPrIssues();
             const labeled = await github.paginate(github.rest.issues.listForRepo, { owner, repo, state: 'all', labels: 'in-pr', per_page: 100 });
             for (const issue of labeled) {
-              if (!issue.pull_request && !active.has(issue.number)) await removeLabel(issue.number, 'in-pr');
+              if (!issue.pull_request && !activeStagingPrIssues.has(issue.number)) await removeLabel(issue.number, 'in-pr');
             }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ This file is a thin maintainer note for contributors using coding agents. Canoni
 
 ## Preferred Workflow
 
-- Start from `main` and open an issue before implementation.
+- Start from `staging` and open an issue before implementation.
 - Open a draft PR when issue work begins so ownership is visible, then mark it ready only after validation and self-review are complete.
 - Run `node scripts/test-catalog-lanes.mjs` and `node scripts/validate-catalog.mjs` as the baseline validation commands.
 - Rebuild the affected package and catalog entry whenever source payloads, manifests, Engine snapshots, or generated bundles change.
@@ -28,4 +28,6 @@ This file is a thin maintainer note for contributors using coding agents. Canoni
 
 - Never auto-check validation or test-plan checkboxes. They are a human verification list, not proof.
 - Explain why the package or repository change is needed, not only which files changed.
-- Link the issue, target `main`, leave drafts unreviewed by CodeRabbit until they are marked ready, and address actionable review feedback before merge.
+- Link the issue, target `staging`, leave drafts unreviewed by CodeRabbit until they are marked ready, and address actionable review feedback before merge.
+- Required checks and CodeRabbit must complete before every `staging` merge. Pasta-Devs developers may then merge without another human approval; outside and first-time contributors require approval from `@Pasta-Devs/developers`.
+- Only `SpicyMarinara` may promote `staging` into `main`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,23 +6,26 @@ Thank you for helping improve the official downloadable packages for [Marinara E
 
 1. Open an issue or check the [issue tracker](https://github.com/Pasta-Devs/Marinara-Agents/issues) before implementing a new package or material behavior change. This lets maintainers agree on scope and prevents duplicate work.
 2. Check for an issue-linked branch, open or draft PR, and visible owner before beginning work.
-3. Base changes on `main`, the protected branch containing the published catalog consumed by Marinara Engine.
+3. Base changes on `staging`, the protected testing branch consumed by Marinara Engine staging users.
 
 ## Branches
 
 | Branch | Role |
 | --- | --- |
-| `main` | Protected development and release branch. Package, catalog, documentation, and CI pull requests target this branch. |
+| `staging` | Active development and Agent testing. This is the only target for package, catalog, documentation, and CI pull requests. |
+| `main` | Stable published catalog. Only `SpicyMarinara` may promote tested work from `staging`. |
 
-Create a focused feature branch from current main:
+Create a focused feature branch from current staging:
 
 ```bash
-git checkout main
+git checkout staging
 git pull
 git checkout -b feature/short-description
 ```
 
-Open a draft PR as soon as implementation starts, then mark it **Ready for review** after validation and self-review. Draft PRs cannot merge and are intentionally skipped by CodeRabbit. Ready PRs receive an automatic CodeRabbit review and require at least one approving review before merge.
+Open a draft PR against `staging` as soon as implementation starts, then mark it **Ready for review** after validation and self-review. Draft PRs cannot merge and are intentionally skipped by CodeRabbit. Every ready PR must pass the catalog check and complete CodeRabbit review. Pasta-Devs members in `@Pasta-Devs/developers` may then merge into `staging` without a separate human approval; outside and first-time contributors also require at least one approving review from that team. Only `SpicyMarinara` may promote `staging` into `main`.
+
+Marinara Engine automatically follows the matching Agent channel: Engine `staging` reads this repository's `staging` catalog and artifacts, while stable Engine builds read `main`. Test package installs and updates from an Engine staging checkout before promotion.
 
 ## Requirements and Setup
 
@@ -97,11 +100,11 @@ Also manually install or update affected packages through **Agents → Download 
 ## Pull Request Expectations
 
 - Link the issue with `Closes #<number>`, `Fixes #<number>`, or `Resolves #<number>`.
-- Target `main`.
+- Target `staging`; contributions to `main` are not accepted.
 - Keep the PR focused and explain the user-facing reason for the change.
 - Mark the PR ready for review only after local validation and self-review.
 - Let CodeRabbit review the ready PR and address actionable findings.
-- Obtain at least one approving review before merge.
+- Outside and first-time contributors must obtain at least one approving review from `@Pasta-Devs/developers`. Team members may merge after the required automated gates pass.
 - Update the README and linked Engine documentation when catalog membership, compatibility, setup, or user-visible behavior changes.
 - Include the generated package and catalog outputs when payloads change.
 - Never commit credentials, private user data, local model files, or unreviewed executable archives.
@@ -120,7 +123,7 @@ A new package must include:
 
 Security-sensitive permissions and executable client/server entrypoints must be narrowly scoped and justified in the PR description.
 
-Package hashes are integrity checks, not independent publisher signatures. A contributor who can change both an artifact and its catalog entry can also change the recorded hash. For that reason, changes under `packages/`, `sources/`, `artifacts/`, `catalog/`, `scripts/`, or `.github/workflows/` require the code-owner review configured in `.github/CODEOWNERS`. Maintainers must keep **Require review from Code Owners** and stale-approval dismissal enabled for `main`; see [SECURITY.md](SECURITY.md) for the full repository ruleset.
+Package hashes are integrity checks, not independent publisher signatures. A contributor who can change both an artifact and its catalog entry can also change the recorded hash. For that reason, sensitive paths map to `@Pasta-Devs/developers` in `.github/CODEOWNERS`. Maintainers must keep Code Owner review and stale-approval dismissal enabled for outside contributions to `staging`, while team members use the staging-only review bypass. `main` must remain owner-only; see [SECURITY.md](SECURITY.md) for the full repository ruleset.
 
 ## AI Agent Workflow
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Conversation mode's About Me profile and `update_about_me` tool are built into M
 
 ## Contributing
 
-Agent ideas, bugs, documentation corrections, and package improvements are welcome. Read [CONTRIBUTING.md](CONTRIBUTING.md) before starting: contributions begin with an issue, target the `main` branch, must be marked ready for review, and require an approving review before merge. CodeRabbit automatically reviews ready pull requests.
+Agent ideas, bugs, documentation corrections, and package improvements are welcome. Read [CONTRIBUTING.md](CONTRIBUTING.md) before starting: contributions begin with an issue and target the `staging` branch. Engine staging users automatically consume Agents staging for package testing. Every ready PR must pass validation and CodeRabbit; outside and first-time contributors also need a Pasta-Devs developer's approval. Only `SpicyMarinara` promotes tested staging work to `main`.
 
 ## Maintainer build
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,8 +11,8 @@ Marinara Agent packages may contain server and client entrypoints. Server entryp
 Catalog SHA-256 values detect accidental corruption and mismatched downloads. They do not protect against an attacker who can change both an artifact and its catalog hash. The repository therefore also:
 
 - requires canonical same-repository artifact URLs during catalog validation;
-- maps security-sensitive paths to a maintainer in `CODEOWNERS`;
+- maps security-sensitive paths to the Pasta-Devs developer team in `CODEOWNERS`;
 - validates source manifests, archive contents, file hashes, catalog lanes, and generated outputs in pull requests; and
 - pins third-party GitHub Actions by full commit SHA.
 
-Repository administrators should keep `main` protected with pull requests required, Code Owner review required, stale approvals dismissed after new commits, the catalog validation check required, force pushes and branch deletion disabled, and administrator bypass restricted. `CODEOWNERS` requests review, but GitHub enforces it only when the matching branch-protection or ruleset option is enabled.
+Repository administrators should keep `staging` protected with pull requests, catalog validation, CodeRabbit, stale-approval dismissal, and Code Owner review required for contributors outside `@Pasta-Devs/developers`. The developer team's bypass must apply only to the human-review rule and only through pull requests; it must not bypass automated checks. Keep force pushes and branch deletion disabled. Protect `main` separately so only `SpicyMarinara` may promote tested work from `staging`.


### PR DESCRIPTION
Closes #115

## Why this change

Marinara-Agents needs a protected testing lane so Agent packages can be exercised by Engine staging users before stable publication. The former policy sent development PRs directly to `main`.

## What changed

- Restore `staging` from the current `main` tip and make it the only contribution target.
- Configure ready PRs to receive CodeRabbit review on `staging`.
- Assign sensitive paths to the Pasta-Devs developer team.
- Update issue status automation, security guidance, contributor docs, and PR instructions.
- Reserve `main` promotion for `SpicyMarinara`.

## Package and security impact

- Affected package IDs: none
- Engine compatibility impact: Engine staging will select Agents staging; stable Engine remains on Agents main
- New or changed permissions/entrypoints: none
- Restart, storage, update, or uninstall impact: none

## Validation

- [ ] `node scripts/validate-catalog.mjs` passes locally
- [ ] `git diff --check` passes locally
- [ ] Rebuilt every affected manifest, payload, artifact, and catalog entry
- [ ] Installed or updated the affected package through Marinara Engine
- [ ] Checked supported modes, restart behavior, and uninstall cleanup
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Governance-only change; catalog validation pending.

## Documentation impact

- [ ] No documentation changes needed
- [ ] Updated this README catalog and package guidance
- [ ] Updated linked Marinara Engine documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated contribution guidance to use `staging` as the default branch for development and pull requests.
  - Clarified review, validation, security, and release-promotion requirements.
  - Documented how staging environments support package testing before release.

- **Process Improvements**
  - Updated automated review and issue-tracking workflows to focus on staging changes.
  - Added clearer issue labeling for fixes completed in staging.
  - Refined ownership and approval expectations for repository changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->