### PR TITLE
Resolve owner-gate membership from the PR API

### DIFF
--- a/.github/workflows/pull-request-triage.yml
+++ b/.github/workflows/pull-request-triage.yml
@@ -50,8 +50,12 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
-            const pr = context.payload.pull_request;
-            if (pr.base?.ref !== 'staging') return;
+            const pullNumber = context.payload.pull_request.number;
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pullNumber,
+            });
 
             if (pr.author_association === 'OWNER' || pr.author_association === 'MEMBER') {
               core.notice(`Internal ${pr.author_association.toLowerCase()} contribution; owner approval is not required.`);
@@ -61,7 +65,7 @@ jobs:
             const reviews = await github.paginate(github.rest.pulls.listReviews, {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: pr.number,
+              pull_number: pullNumber,
               per_page: 100,
             });
             const ownerReviews = reviews


### PR DESCRIPTION
Closes #120

## Why this change

The owner-approval gate must distinguish Pasta-Devs members from outside contributors on both pull-request and review events. Some pull_request_review payloads omit author_association, which can falsely classify an internal member as outside.

## What changed

- Fetch the canonical pull request record before evaluating author association.
- Continue bypassing owner approval only for OWNER and MEMBER contributions.
- Keep current-head SpicyMarinara approval mandatory for every actual outside or first-time contributor.
- Retain the CodeRabbit-requested job-level staging condition.

## Package and security impact

- Affected package IDs: none
- Engine compatibility impact: none
- New or changed permissions/entrypoints: none; the job already has pull-request read permission
- Restart, storage, update, or uninstall impact: none

## Validation

- [ ] `node scripts/validate-catalog.mjs` passes locally
- [ ] `git diff --check` passes locally
- [ ] Rebuilt every affected manifest, payload, artifact, and catalog entry
- [ ] Installed or updated the affected package through Marinara Engine
- [ ] Checked supported modes, restart behavior, and uninstall cleanup
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Workflow YAML parses successfully.
- Catalog and lane validation pass.
- The live Engine workflow reproduced the missing webhook association while the canonical PR API reported MEMBER.

## Documentation impact

- [ ] No documentation changes needed
- [ ] Updated this README catalog and package guidance
- [ ] Updated linked Marinara Engine documentation