### PR TITLE
fix: skip auto-label writes on review events

### DIFF
--- a/.github/workflows/pull-request-triage.yml
+++ b/.github/workflows/pull-request-triage.yml
@@ -149,6 +149,7 @@ jobs:
 
   label:
     name: Auto-label
+    if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Linked issue

Closes #192

## Why this change

- Review events on personal-fork pull requests receive a read-only workflow token. The auto-label job attempted repository writes anyway, failed with `Resource not accessible by integration`, and could block an otherwise mergeable member PR.

## What changed

- Run auto-label writes only on `pull_request_target`, where the workflow has the required repository permissions.
- Preserve the review-event membership classification merged with #191.

## Package and security impact

- Affected package IDs: None
- Engine compatibility impact: None
- New or changed permissions/entrypoints: No new permissions; fork review events no longer attempt writes
- Restart, storage, update, or uninstall impact: None

## Validation

- [ ] `node scripts/test-catalog-lanes.mjs` passes locally
- [ ] `node scripts/validate-catalog.mjs` passes locally
- [ ] `git diff --check` passes locally
- [ ] Reviewed the workflow's pull-request-target and review-event paths
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- Verify a fork PR review event skips the auto-label job without a permissions failure.
- Verify auto-labeling still runs on pull-request target events.

## Documentation impact

- [ ] No documentation changes needed
- [ ] Updated this README catalog and package guidance
- [ ] Updated linked Marinara Engine documentation

## UI evidence (if applicable)

- Not applicable; workflow-only change.
