### PR TITLE
Prepare package localization catalogs

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Test catalog lane routing and build provenance
         run: node scripts/test-catalog-lanes.mjs
 
+      - name: Validate package localization catalogs
+        run: node scripts/validate-package-locales.mjs
+
       - name: Validate catalogs, packages, artifacts, and README coverage
         run: node scripts/validate-catalog.mjs
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ This file is a thin maintainer note for contributors using coding agents. Canoni
 
 - Start from `staging` and open an issue before implementation.
 - Open a draft PR when issue work begins so ownership is visible, then mark it ready only after validation and self-review are complete.
-- Run `node scripts/test-catalog-lanes.mjs` and `node scripts/validate-catalog.mjs` as the baseline validation commands.
+- Run `node scripts/test-catalog-lanes.mjs`, `node scripts/validate-package-locales.mjs`, and `node scripts/validate-catalog.mjs` as the baseline validation commands.
 - Rebuild the affected package and catalog entry whenever source payloads, manifests, Engine snapshots, or generated bundles change.
 - Treat each manifest's `engine.min` / `engine.maxExclusive` range as the catalog-lane source of truth. The builders route packages into `catalog/v*/catalog.json`; do not hand-place or copy entries between lanes.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,11 +97,26 @@ Every pull request must run:
 
 ```bash
 node scripts/test-catalog-lanes.mjs
+node scripts/validate-package-locales.mjs
 node scripts/validate-catalog.mjs
 git diff --check
 ```
 
 Catalog validation verifies every versioned lane and the legacy alias, package count and identity, Engine compatibility, categories, README coverage, package manifests, permissions, entrypoints, declared file hashes and sizes, ZIP checksums and contents, generated JavaScript syntax, runtime registration, and package-specific contracts.
+
+### Localizing package metadata
+
+Each downloadable package owns a canonical `packages/<id>/locales/en.json` catalog for its user-visible package metadata. It includes the package and installed-Agent names and descriptions plus names and descriptions for selectable prompt templates. Model prompt templates are behavior, not interface copy, and must not be translated.
+
+The English catalogs are generated from `manifest.json` and `agents.json`. After changing those source strings, run:
+
+```bash
+node scripts/sync-package-locales.mjs
+```
+
+For a translation, copy the package's English catalog to a BCP 47 locale filename such as `ko.json` or `pt-BR.json`, update `_meta`, and translate only the fields you can maintain. Translated catalogs may be partial; missing fields fall back to English when Engine consumption is implemented. Keep Agent and prompt-template IDs unchanged, preserve the file structure, and run `node scripts/validate-package-locales.mjs` before opening a PR.
+
+These package-adjacent metadata catalogs do not localize executable package interfaces by themselves. Package-owned interfaces keep their own UI catalogs, such as Long-Term Memory's `src/engine/.../locales/en.json`. Loading localized package metadata in **Agents → Download Agents** remains Engine-owned integration work; do not extend the strict Engine manifest or catalog schema from this repository alone.
 
 Also manually install or update affected packages through **Agents → Download Agents** in a compatible Marinara Engine checkout. Verify the supported chat modes, restart behavior, uninstall cleanup, and an offline restart when relevant. Describe exactly what was tested in the PR; do not tick checklist items that were not personally verified.
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ Across its Engine compatibility lanes, the catalog currently contains **31 first
 
 For complete mode, lifecycle, and settings documentation for every package, see the Engine's [Downloadable Agents Reference](https://github.com/Pasta-Devs/Marinara-Engine/blob/staging/docs/agents/built-in-agents.md).
 
+### Localization sources
+
+Every downloadable package keeps its canonical user-visible metadata in `packages/<id>/locales/en.json`. These catalogs cover package and Agent names and descriptions plus selectable named prompt options, while deliberately excluding model instructions. Translators can add partial BCP 47 catalogs such as `ko.json`; untranslated fields fall back to English once Engine-side catalog localization support consumes them. See [Contributing](CONTRIBUTING.md#localizing-package-metadata) for the format and validation workflow.
+
+Package-owned interfaces maintain their UI catalogs separately. The metadata catalogs prepared here do not change the Engine's catalog schema or runtime behavior on their own.
+
 ## Package trust and storage
 
 The Engine downloads only entries from its Engine-major lane in this official HTTPS catalog, validates the catalog schema, checks Engine version compatibility, verifies the archive SHA-256 checksum, rejects unsafe archive paths and undeclared files, validates each declared file hash and size, and installs atomically into the Engine data directory. Installed packages remain available offline. Server-capability packages run with their declared permissions and require a restart when their runtime changes.

--- a/packages/background/locales/en.json
+++ b/packages/background/locales/en.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../../schemas/package-localization.schema.json",
+  "_meta": {
+    "locale": "en",
+    "direction": "ltr"
+  },
+  "package": {
+    "name": "Background",
+    "description": "Selects the most fitting existing background image for the current scene from your background library. Add the Agent in Chat Settings → Agents → Tracker Agents for Roleplay mode."
+  },
+  "agents": {
+    "background": {
+      "name": "Background",
+      "description": "Selects the most fitting existing background image for the current scene from your background library. Add the Agent in Chat Settings → Agents → Tracker Agents for Roleplay mode."
+    }
+  }
+}

--- a/packages/card-evolution-auditor/locales/en.json
+++ b/packages/card-evolution-auditor/locales/en.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../../schemas/package-localization.schema.json",
+  "_meta": {
+    "locale": "en",
+    "direction": "ltr"
+  },
+  "package": {
+    "name": "Card Evolution Auditor",
+    "description": "Audits durable roleplay changes against saved character cards and proposes precise edits for user approval. Add the Agent in Chat Settings → Agents → Writer Agents for Roleplay mode."
+  },
+  "agents": {
+    "card-evolution-auditor": {
+      "name": "Card Evolution Auditor",
+      "description": "Audits durable roleplay changes against saved character cards and proposes precise edits for user approval. Add the Agent in Chat Settings → Agents → Writer Agents for Roleplay mode."
+    }
+  }
+}

--- a/packages/character-tracker/locales/en.json
+++ b/packages/character-tracker/locales/en.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../../schemas/package-localization.schema.json",
+  "_meta": {
+    "locale": "en",
+    "direction": "ltr"
+  },
+  "package": {
+    "name": "Character Tracker",
+    "description": "Tracks which characters are present in the scene, their mood, actions, appearance, outfit, thoughts, and per-character stats (HP, etc.). Add the Agent in Chat Settings → Agents → Tracker Agents for Roleplay mode."
+  },
+  "agents": {
+    "character-tracker": {
+      "name": "Character Tracker",
+      "description": "Tracks which characters are present in the scene, their mood, actions, appearance, outfit, thoughts, and per-character stats (HP, etc.). Add the Agent in Chat Settings → Agents → Tracker Agents for Roleplay mode."
+    }
+  }
+}

--- a/packages/chess/locales/en.json
+++ b/packages/chess/locales/en.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../../schemas/package-localization.schema.json",
+  "_meta": {
+    "locale": "en",
+    "direction": "ltr"
+  },
+  "package": {
+    "name": "Chess",
+    "description": "Play Chess with a Conversation character. Install to use /chess manually in any Conversation chat. Add under Chat Settings → Agents → Commands only to let characters initiate it."
+  },
+  "agents": {
+    "chess": {
+      "name": "Chess",
+      "description": "Play Chess with a Conversation character. Install to use /chess manually in any Conversation chat. Add under Chat Settings → Agents → Commands only to let characters initiate it."
+    }
+  }
+}

--- a/packages/combat/locales/en.json
+++ b/packages/combat/locales/en.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../../schemas/package-localization.schema.json",
+  "_meta": {
+    "locale": "en",
+    "direction": "ltr"
+  },
+  "package": {
+    "name": "Combat",
+    "description": "Manages combat encounters, initiative, HP tracking, and turn-based actions. Add as an Agent in Chat Settings → Agents → Misc Agents for Roleplay mode."
+  },
+  "agents": {
+    "combat": {
+      "name": "Combat",
+      "description": "Manages combat encounters, initiative, HP tracking, and turn-based actions. Add as an Agent in Chat Settings → Agents → Misc Agents for Roleplay mode."
+    }
+  }
+}

--- a/packages/continuity/locales/en.json
+++ b/packages/continuity/locales/en.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../../schemas/package-localization.schema.json",
+  "_meta": {
+    "locale": "en",
+    "direction": "ltr"
+  },
+  "package": {
+    "name": "Continuity Checker",
+    "description": "Post-processes the latest assistant message to fix concrete spatial, timeline, and physical logic errors without changing the story. Add the Agent in Chat Settings → Agents → Writer Agents for Roleplay mode."
+  },
+  "agents": {
+    "continuity": {
+      "name": "Continuity Checker",
+      "description": "Post-processes the latest assistant message to fix concrete spatial, timeline, and physical logic errors without changing the story. Add the Agent in Chat Settings → Agents → Writer Agents for Roleplay mode."
+    }
+  }
+}

--- a/packages/conversation-calls/locales/en.json
+++ b/packages/conversation-calls/locales/en.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../../schemas/package-localization.schema.json",
+  "_meta": {
+    "locale": "en",
+    "direction": "ltr"
+  },
+  "package": {
+    "name": "Calls",
+    "description": "Adds live audio and video calls with Conversation characters. Add as both a Command and an Agent in Chat Settings → Agents → Commands/Calls for Conversation mode."
+  },
+  "agents": {
+    "conversation-calls": {
+      "name": "Calls",
+      "description": "Adds live audio and video calls with Conversation characters. Add as both a Command and an Agent in Chat Settings → Agents → Commands/Calls for Conversation mode."
+    }
+  }
+}

--- a/packages/custom-tracker/locales/en.json
+++ b/packages/custom-tracker/locales/en.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../../schemas/package-localization.schema.json",
+  "_meta": {
+    "locale": "en",
+    "direction": "ltr"
+  },
+  "package": {
+    "name": "Custom Tracker",
+    "description": "Tracks user-defined fields (currencies, counters, flags, or any custom data). Add any fields you want the model to keep track of during the roleplay. Add the Agent in Chat Settings → Agents → Tracker Agents for Roleplay mode."
+  },
+  "agents": {
+    "custom-tracker": {
+      "name": "Custom Tracker",
+      "description": "Tracks user-defined fields (currencies, counters, flags, or any custom data). Add any fields you want the model to keep track of during the roleplay. Add the Agent in Chat Settings → Agents → Tracker Agents for Roleplay mode."
+    }
+  }
+}

--- a/packages/cyoa/locales/en.json
+++ b/packages/cyoa/locales/en.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../../schemas/package-localization.schema.json",
+  "_meta": {
+    "locale": "en",
+    "direction": "ltr"
+  },
+  "package": {
+    "name": "CYOA Choices",
+    "description": "Generates interactive Choose Your Own Adventure choices after each assistant message. Click a choice to send it as your response. Available in Roleplay chats. Add the Agent in Chat Settings → Agents → Misc Agents for Roleplay mode."
+  },
+  "agents": {
+    "cyoa": {
+      "name": "CYOA Choices",
+      "description": "Generates interactive Choose Your Own Adventure choices after each assistant message. Click a choice to send it as your response. Available in Roleplay chats. Add the Agent in Chat Settings → Agents → Misc Agents for Roleplay mode."
+    }
+  }
+}

--- a/packages/director/locales/en.json
+++ b/packages/director/locales/en.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../../schemas/package-localization.schema.json",
+  "_meta": {
+    "locale": "en",
+    "direction": "ltr"
+  },
+  "package": {
+    "name": "Narrative Director",
+    "description": "Creates one-shot story directions when you choose to push the next response forward. Add the Agent in Chat Settings → Agents → Writer Agents for Roleplay mode."
+  },
+  "agents": {
+    "director": {
+      "name": "Narrative Director",
+      "description": "Creates one-shot story directions when you choose to push the next response forward. Add the Agent in Chat Settings → Agents → Writer Agents for Roleplay mode."
+    }
+  }
+}

--- a/packages/echo-chamber/locales/en.json
+++ b/packages/echo-chamber/locales/en.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "../../../schemas/package-localization.schema.json",
+  "_meta": {
+    "locale": "en",
+    "direction": "ltr"
+  },
+  "package": {
+    "name": "Echo Chamber",
+    "description": "Simulates a live streaming-style chat reacting to your roleplay in real time. Add the Agent in Chat Settings → Agents → Misc Agents for Roleplay mode."
+  },
+  "agents": {
+    "echo-chamber": {
+      "name": "Echo Chamber",
+      "description": "Simulates a live streaming-style chat reacting to your roleplay in real time. Add the Agent in Chat Settings → Agents → Misc Agents for Roleplay mode.",
+      "promptTemplates": {
+        "ao3-wattpad": {
+          "name": "AO3 / Wattpad",
+          "description": "Fanfic comment-section energy: shipping, kudos, screaming, favorite lines, and reader speculation."
+        },
+        "twitter-reddit": {
+          "name": "Twitter / Reddit",
+          "description": "A mix of quote-tweet reactions, thread jokes, hot takes, and subreddit analysis."
+        },
+        "imageboard": {
+          "name": "4chan",
+          "description": "Anonymous imageboard chaos with greentext cadence, bait, and blunt reactions."
+        },
+        "constructive": {
+          "name": "Constructive",
+          "description": "Thoughtful reactions that point out strengths, pacing, continuity, and possible next beats."
+        },
+        "hype-squad": {
+          "name": "Hype Squad",
+          "description": "Maximum cheering, caps, celebration, cheering-on, and dramatic overreaction."
+        },
+        "harbingers": {
+          "name": "Harbingers",
+          "description": "Fatui Harbingers and agents reacting from the peanut gallery."
+        }
+      }
+    }
+  }
+}

--- a/packages/eightball/locales/en.json
+++ b/packages/eightball/locales/en.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../../schemas/package-localization.schema.json",
+  "_meta": {
+    "locale": "en",
+    "direction": "ltr"
+  },
+  "package": {
+    "name": "8-Ball Pool",
+    "description": "Play 8-Ball Pool with a Conversation character. Install to use /8ball manually in any Conversation chat. Add under Chat Settings → Agents → Commands only to let characters initiate it."
+  },
+  "agents": {
+    "eightball": {
+      "name": "8-Ball Pool",
+      "description": "Play 8-Ball Pool with a Conversation character. Install to use /8ball manually in any Conversation chat. Add under Chat Settings → Agents → Commands only to let characters initiate it."
+    }
+  }
+}

--- a/packages/expression/locales/en.json
+++ b/packages/expression/locales/en.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../../schemas/package-localization.schema.json",
+  "_meta": {
+    "locale": "en",
+    "direction": "ltr"
+  },
+  "package": {
+    "name": "Expression Engine",
+    "description": "Detects character emotions and selects VN sprites/expressions. Add the Agent in Chat Settings → Agents → Tracker Agents for Roleplay mode."
+  },
+  "agents": {
+    "expression": {
+      "name": "Expression Engine",
+      "description": "Detects character emotions and selects VN sprites/expressions. Add the Agent in Chat Settings → Agents → Tracker Agents for Roleplay mode."
+    }
+  }
+}

--- a/packages/haptic/locales/en.json
+++ b/packages/haptic/locales/en.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../../schemas/package-localization.schema.json",
+  "_meta": {
+    "locale": "en",
+    "direction": "ltr"
+  },
+  "package": {
+    "name": "Haptic Feedback",
+    "description": "Analyzes narrative content and controls connected intimate toys in real time. Requires Intiface Central running locally — connect your toy there first, then enable this agent. Add as both a Command and an Agent in Chat Settings → Agents → Commands/Misc Agents for Conversation and Roleplay modes."
+  },
+  "agents": {
+    "haptic": {
+      "name": "Haptic Feedback",
+      "description": "Analyzes narrative content and controls connected intimate toys in real time. Requires Intiface Central running locally — connect your toy there first, then enable this agent. Add as both a Command and an Agent in Chat Settings → Agents → Commands/Misc Agents for Conversation and Roleplay modes."
+    }
+  }
+}

--- a/packages/hierarchical-maps/locales/en.json
+++ b/packages/hierarchical-maps/locales/en.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../../schemas/package-localization.schema.json",
+  "_meta": {
+    "locale": "en",
+    "direction": "ltr"
+  },
+  "package": {
+    "name": "World Maps",
+    "description": "Adds persistent hierarchical locations, durable shared worlds, reusable artwork, customizable Direct Link lines, and movement to Roleplay and Game. Add the Agent in Chat Settings → Agents → Tracker Agents for Roleplay and Game modes."
+  },
+  "agents": {
+    "hierarchical-maps": {
+      "name": "World Maps",
+      "description": "Adds persistent hierarchical locations, durable shared worlds, reusable artwork, customizable Direct Link lines, and movement to Roleplay and Game. Add the Agent in Chat Settings → Agents → Tracker Agents for Roleplay and Game modes."
+    }
+  }
+}

--- a/packages/html/locales/en.json
+++ b/packages/html/locales/en.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../../schemas/package-localization.schema.json",
+  "_meta": {
+    "locale": "en",
+    "direction": "ltr"
+  },
+  "package": {
+    "name": "Immersive HTML",
+    "description": "Post-processes the latest Roleplay response with diegetic HTML/CSS/JS visual artifacts without changing the story meaning. Add the Agent in Chat Settings → Agents → Misc Agents for Roleplay mode."
+  },
+  "agents": {
+    "html": {
+      "name": "Immersive HTML",
+      "description": "Post-processes the latest Roleplay response with diegetic HTML/CSS/JS visual artifacts without changing the story meaning. Add the Agent in Chat Settings → Agents → Misc Agents for Roleplay mode."
+    }
+  }
+}

--- a/packages/illustrator/locales/en.json
+++ b/packages/illustrator/locales/en.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "../../../schemas/package-localization.schema.json",
+  "_meta": {
+    "locale": "en",
+    "direction": "ltr"
+  },
+  "package": {
+    "name": "Illustrator",
+    "description": "Creates images and videos, with optional automatic scene backgrounds for Roleplay location changes. Add as both a Command and an Agent in Chat Settings → Agents → Commands/Misc Agents/Illustrator for Conversation, Roleplay, and Game modes."
+  },
+  "agents": {
+    "illustrator": {
+      "name": "Illustrator",
+      "description": "Creates images and videos, with optional automatic scene backgrounds for Roleplay location changes. Add as both a Command and an Agent in Chat Settings → Agents → Commands/Misc Agents/Illustrator for Conversation, Roleplay, and Game modes.",
+      "promptTemplates": {
+        "comic-page": {
+          "name": "Comic Page",
+          "description": "Panelled comic page with dialogue, captions, and SFX."
+        },
+        "colored-manga": {
+          "name": "Colored Manga",
+          "description": "Colored manga scene with stylized dialogue and SFX."
+        },
+        "bw-manga": {
+          "name": "B&W Manga",
+          "description": "Black-and-white manga with dialogue, SFX, inks, and screentones."
+        },
+        "background": {
+          "name": "Background",
+          "description": "Environment or establishing-shot background without characters."
+        },
+        "selfie": {
+          "name": "Selfie",
+          "description": "In-character selfie or casual portrait prompt."
+        }
+      }
+    }
+  }
+}

--- a/packages/knowledge-retrieval/locales/en.json
+++ b/packages/knowledge-retrieval/locales/en.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../../schemas/package-localization.schema.json",
+  "_meta": {
+    "locale": "en",
+    "direction": "ltr"
+  },
+  "package": {
+    "name": "Knowledge Retrieval",
+    "description": "Scans specified lorebooks for information relevant to the current conversation, summarizes the key data, and injects it into the prompt — a lightweight RAG pipeline without vector databases. Add the Agent in Chat Settings → Agents → Writer Agents for Roleplay mode."
+  },
+  "agents": {
+    "knowledge-retrieval": {
+      "name": "Knowledge Retrieval",
+      "description": "Scans specified lorebooks for information relevant to the current conversation, summarizes the key data, and injects it into the prompt — a lightweight RAG pipeline without vector databases. Add the Agent in Chat Settings → Agents → Writer Agents for Roleplay mode."
+    }
+  }
+}

--- a/packages/knowledge-router/locales/en.json
+++ b/packages/knowledge-router/locales/en.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../../schemas/package-localization.schema.json",
+  "_meta": {
+    "locale": "en",
+    "direction": "ltr"
+  },
+  "package": {
+    "name": "Knowledge Router",
+    "description": "Lower-cost alternative to Knowledge Retrieval. Reads a short catalog of lorebook entries (descriptions or content snippets), picks which ones are relevant to the current scene, and injects them verbatim — no per-entry summarization passes. Best for large lorebooks where you've written entry descriptions. Add the Agent in Chat Settings → Agents → Writer Agents for Roleplay mode."
+  },
+  "agents": {
+    "knowledge-router": {
+      "name": "Knowledge Router",
+      "description": "Lower-cost alternative to Knowledge Retrieval. Reads a short catalog of lorebook entries (descriptions or content snippets), picks which ones are relevant to the current scene, and injects them verbatim — no per-entry summarization passes. Best for large lorebooks where you've written entry descriptions. Add the Agent in Chat Settings → Agents → Writer Agents for Roleplay mode."
+    }
+  }
+}

--- a/packages/long-term-memory/locales/en.json
+++ b/packages/long-term-memory/locales/en.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../../schemas/package-localization.schema.json",
+  "_meta": {
+    "locale": "en",
+    "direction": "ltr"
+  },
+  "package": {
+    "name": "Long-Term Memory",
+    "description": "Extracts durable memories from chat summaries, character records, and lorebooks, then recalls relevant context from a package-owned vault. Enable it per chat from Chat Settings → Agents → Long-Term Memory. In Roleplay and Game, you can also add it from Chat Settings → Agents → Misc Agents."
+  },
+  "agents": {
+    "long-term-memory": {
+      "name": "Long-Term Memory",
+      "description": "Extracts durable memories from chat summaries, character records, and lorebooks, then recalls relevant context from a package-owned vault. Enable it per chat from Chat Settings → Agents → Long-Term Memory. In Roleplay and Game, you can also add it from Chat Settings → Agents → Misc Agents."
+    }
+  }
+}

--- a/packages/lorebook-keeper/locales/en.json
+++ b/packages/lorebook-keeper/locales/en.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../../schemas/package-localization.schema.json",
+  "_meta": {
+    "locale": "en",
+    "direction": "ltr"
+  },
+  "package": {
+    "name": "Lorebook Keeper",
+    "description": "Creates and updates durable chat lorebook entries from important story facts, characters, places, and world changes. Add the Agent in Chat Settings → Agents → Misc Agents/Lorebook Keeper for Roleplay and Game modes."
+  },
+  "agents": {
+    "lorebook-keeper": {
+      "name": "Lorebook Keeper",
+      "description": "Creates and updates durable chat lorebook entries from important story facts, characters, places, and world changes. Add the Agent in Chat Settings → Agents → Misc Agents/Lorebook Keeper for Roleplay and Game modes."
+    }
+  }
+}

--- a/packages/persona-stats/locales/en.json
+++ b/packages/persona-stats/locales/en.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../../schemas/package-localization.schema.json",
+  "_meta": {
+    "locale": "en",
+    "direction": "ltr"
+  },
+  "package": {
+    "name": "Persona Stats",
+    "description": "Tracks the player persona's status bars — Satiety, Energy, Hygiene, and other custom stats — with realistic changes based on narrative events. Add the Agent in Chat Settings → Agents → Tracker Agents for Roleplay mode."
+  },
+  "agents": {
+    "persona-stats": {
+      "name": "Persona Stats",
+      "description": "Tracks the player persona's status bars — Satiety, Energy, Hygiene, and other custom stats — with realistic changes based on narrative events. Add the Agent in Chat Settings → Agents → Tracker Agents for Roleplay mode."
+    }
+  }
+}

--- a/packages/poker/locales/en.json
+++ b/packages/poker/locales/en.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../../schemas/package-localization.schema.json",
+  "_meta": {
+    "locale": "en",
+    "direction": "ltr"
+  },
+  "package": {
+    "name": "Poker",
+    "description": "Play Texas Hold’em Poker with Conversation characters. Install to use /poker manually in any Conversation chat. Add under Chat Settings → Agents → Commands only to let characters initiate it."
+  },
+  "agents": {
+    "poker": {
+      "name": "Poker",
+      "description": "Play Texas Hold’em Poker with Conversation characters. Install to use /poker manually in any Conversation chat. Add under Chat Settings → Agents → Commands only to let characters initiate it."
+    }
+  }
+}

--- a/packages/prose-guardian/locales/en.json
+++ b/packages/prose-guardian/locales/en.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../../schemas/package-localization.schema.json",
+  "_meta": {
+    "locale": "en",
+    "direction": "ltr"
+  },
+  "package": {
+    "name": "Prose Guardian",
+    "description": "Post-processes the latest assistant message to remove banned words, repetition, and unwanted prose habits without changing the meaning. Add the Agent in Chat Settings → Agents → Writer Agents for Roleplay mode."
+  },
+  "agents": {
+    "prose-guardian": {
+      "name": "Prose Guardian",
+      "description": "Post-processes the latest assistant message to remove banned words, repetition, and unwanted prose habits without changing the meaning. Add the Agent in Chat Settings → Agents → Writer Agents for Roleplay mode."
+    }
+  }
+}

--- a/packages/quest/locales/en.json
+++ b/packages/quest/locales/en.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../../schemas/package-localization.schema.json",
+  "_meta": {
+    "locale": "en",
+    "direction": "ltr"
+  },
+  "package": {
+    "name": "Quest Tracker",
+    "description": "Manages quest objectives, completion states, and rewards. Add the Agent in Chat Settings → Agents → Tracker Agents for Roleplay mode."
+  },
+  "agents": {
+    "quest": {
+      "name": "Quest Tracker",
+      "description": "Manages quest objectives, completion states, and rewards. Add the Agent in Chat Settings → Agents → Tracker Agents for Roleplay mode."
+    }
+  }
+}

--- a/packages/rock-paper-scissors/locales/en.json
+++ b/packages/rock-paper-scissors/locales/en.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../../schemas/package-localization.schema.json",
+  "_meta": {
+    "locale": "en",
+    "direction": "ltr"
+  },
+  "package": {
+    "name": "Rock-Paper-Scissors",
+    "description": "Play Rock-Paper-Scissors with a Conversation character. Install to use /rps manually in any Conversation chat. Add under Chat Settings → Agents → Commands only to let characters initiate it."
+  },
+  "agents": {
+    "rock-paper-scissors": {
+      "name": "Rock-Paper-Scissors",
+      "description": "Play Rock-Paper-Scissors with a Conversation character. Install to use /rps manually in any Conversation chat. Add under Chat Settings → Agents → Commands only to let characters initiate it."
+    }
+  }
+}

--- a/packages/spotify/locales/en.json
+++ b/packages/spotify/locales/en.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../../schemas/package-localization.schema.json",
+  "_meta": {
+    "locale": "en",
+    "direction": "ltr"
+  },
+  "package": {
+    "name": "Music DJ",
+    "description": "Analyzes the narrative mood and plays matching music through Spotify, YouTube, or local Game Assets music. Enable the music player in Settings → General. Add both as a Command and an Agent in Chat Settings → Agents → Commands/Misc Agents/Music DJ for Conversation, Roleplay, and Game modes."
+  },
+  "agents": {
+    "spotify": {
+      "name": "Music DJ",
+      "description": "Analyzes the narrative mood and plays matching music through Spotify, YouTube, or local Game Assets music. Enable the music player in Settings → General. Add both as a Command and an Agent in Chat Settings → Agents → Commands/Misc Agents/Music DJ for Conversation, Roleplay, and Game modes."
+    }
+  }
+}

--- a/packages/storyboard/locales/en.json
+++ b/packages/storyboard/locales/en.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "../../../schemas/package-localization.schema.json",
+  "_meta": {
+    "locale": "en",
+    "direction": "ltr"
+  },
+  "package": {
+    "name": "Storyboard",
+    "description": "Plans still or animated Game and Roleplay storyboards with separate planning prompts and shared provider formatters. Add the Agent in Chat Settings → Agents → Misc Agents/Storyboard for Roleplay and Game modes."
+  },
+  "agents": {
+    "storyboard": {
+      "name": "Storyboard",
+      "description": "Plans still or animated Game and Roleplay storyboards with separate planning prompts and shared provider formatters. Add the Agent in Chat Settings → Agents → Misc Agents/Storyboard for Roleplay and Game modes.",
+      "promptTemplates": {
+        "still-keyframes": {
+          "name": "Still Keyframes",
+          "description": "Game Mode storyboard preset for normal viewing. Creates single-scene keyframes and avoids comic text and panels."
+        },
+        "novelai-keyframes": {
+          "name": "NovelAI Keyframes",
+          "description": "Game Mode storyboard preset with compact ASCII Danbooru tags tuned for NovelAI V4/V4.5 and native Add Character prompting."
+        },
+        "comic-page-keyframes": {
+          "name": "Comic Page",
+          "description": "Game Mode illustration preset with comic panels, dialogue, captions, and SFX."
+        },
+        "colored-manga-keyframes": {
+          "name": "Colored Manga",
+          "description": "Game Mode storyboard preset with colored manga styling, panel-like staging, speech bubbles, and SFX."
+        },
+        "bw-manga-keyframes": {
+          "name": "B&W Manga",
+          "description": "Game Mode storyboard preset with black-and-white manga inks, screentones, speech bubbles, and SFX."
+        },
+        "still-keyframes-animation": {
+          "name": "Still Keyframe Animation",
+          "description": "Plans one style-neutral first frame and one achievable continuous motion direction per clip."
+        },
+        "anime-episode-director": {
+          "name": "Anime Episode Director",
+          "description": "Plans broadcast-anime single shots with first-frame continuity, compact motion direction, and provider-safe staging."
+        },
+        "novelai-keyframes-animation": {
+          "name": "NovelAI Keyframe Animation",
+          "description": "Plans NovelAI V4/V4.5 tag-based first frames while keeping timing and motion in a separate animation direction."
+        },
+        "comic-page-animation": {
+          "name": "Comic Page Animation",
+          "description": "Plans duration-aware comic pages as ordered visual references for automatic animations."
+        },
+        "colored-manga-keyframes-animation": {
+          "name": "Colored Manga Animation",
+          "description": "Plans a text-free colored manga first frame with motion that preserves linework and cel shading."
+        },
+        "bw-manga-keyframes-animation": {
+          "name": "B&W Manga Animation",
+          "description": "Plans a text-free monochrome first frame with motion that preserves inks and screentones."
+        },
+        "ltx-director-storyboard": {
+          "name": "LTX Director Storyboard",
+          "description": "Plans one first-frame illustration and one duration-aware LTX 2.3 image-to-video prompt for each shot."
+        },
+        "ltx-simple-image-to-video": {
+          "name": "LTX Simple Image-to-Video",
+          "description": "Plans one first frame and one simple 4-8 sentence LTX 2.3 image-to-video prompt per shot."
+        }
+      }
+    }
+  }
+}

--- a/packages/tic-tac-toe/locales/en.json
+++ b/packages/tic-tac-toe/locales/en.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../../schemas/package-localization.schema.json",
+  "_meta": {
+    "locale": "en",
+    "direction": "ltr"
+  },
+  "package": {
+    "name": "Tic-Tac-Toe",
+    "description": "Play Tic-Tac-Toe with a Conversation character. Install to use /tictactoe manually in any Conversation chat. Add under Chat Settings → Agents → Commands only to let characters initiate it."
+  },
+  "agents": {
+    "tic-tac-toe": {
+      "name": "Tic-Tac-Toe",
+      "description": "Play Tic-Tac-Toe with a Conversation character. Install to use /tictactoe manually in any Conversation chat. Add under Chat Settings → Agents → Commands only to let characters initiate it."
+    }
+  }
+}

--- a/packages/uno/locales/en.json
+++ b/packages/uno/locales/en.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../../schemas/package-localization.schema.json",
+  "_meta": {
+    "locale": "en",
+    "direction": "ltr"
+  },
+  "package": {
+    "name": "UNO",
+    "description": "Play UNO with Conversation characters. Install to use /uno manually in any Conversation chat. Add under Chat Settings → Agents → Commands only to let characters initiate it."
+  },
+  "agents": {
+    "uno": {
+      "name": "UNO",
+      "description": "Play UNO with Conversation characters. Install to use /uno manually in any Conversation chat. Add under Chat Settings → Agents → Commands only to let characters initiate it."
+    }
+  }
+}

--- a/packages/world-state/locales/en.json
+++ b/packages/world-state/locales/en.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../../schemas/package-localization.schema.json",
+  "_meta": {
+    "locale": "en",
+    "direction": "ltr"
+  },
+  "package": {
+    "name": "World State",
+    "description": "Tracks date, time, weather, location, temperature, and custom world details automatically. Add the Agent in Chat Settings → Agents → Tracker Agents for Roleplay mode."
+  },
+  "agents": {
+    "world-state": {
+      "name": "World State",
+      "description": "Tracks date, time, weather, location, temperature, and custom world details automatically. Add the Agent in Chat Settings → Agents → Tracker Agents for Roleplay mode."
+    }
+  }
+}

--- a/schemas/package-localization.schema.json
+++ b/schemas/package-localization.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Pasta-Devs/Marinara-Agents/schemas/package-localization.schema.json",
+  "title": "Marinara package localization catalog",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["$schema", "_meta"],
+  "properties": {
+    "$schema": { "type": "string" },
+    "_meta": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["locale", "direction"],
+      "properties": {
+        "locale": {
+          "type": "string",
+          "pattern": "^[a-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$"
+        },
+        "direction": { "enum": ["ltr", "rtl"] }
+      }
+    },
+    "package": { "$ref": "#/$defs/localizedText" },
+    "agents": {
+      "type": "object",
+      "propertyNames": {
+        "type": "string",
+        "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+      },
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": { "$ref": "#/$defs/nonEmptyText" },
+          "description": { "$ref": "#/$defs/nonEmptyText" },
+          "promptTemplates": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string",
+              "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+            },
+            "additionalProperties": { "$ref": "#/$defs/localizedText" }
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "nonEmptyText": {
+      "type": "string",
+      "minLength": 1
+    },
+    "localizedText": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": { "$ref": "#/$defs/nonEmptyText" },
+        "description": { "$ref": "#/$defs/nonEmptyText" }
+      }
+    }
+  }
+}

--- a/scripts/build-agent-catalog.mjs
+++ b/scripts/build-agent-catalog.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 import { catalogArtworkUrl } from "./catalog-artwork.mjs";
 import { readCatalogFamily, writeCatalogFamily } from "./catalog-lanes.mjs";
 import { withPackageActivationGuidance } from "./catalog-package-guidance.mjs";
+import { writeEnglishPackageLocale } from "./package-locales.mjs";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const artifactsDir = join(repoRoot, "artifacts");
@@ -75,6 +76,7 @@ for (const id of selectedPackageDirectories) {
     files: [{ path: manifest.entrypoints.agents, sha256: sha256(agentsBuffer), bytes: agentsBuffer.byteLength }],
   };
   await writeFile(join(sourceDir, "manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`);
+  await writeEnglishPackageLocale(sourceDir, manifest, agentDefinitions);
 
   const temporary = await mkdtemp(join(tmpdir(), `marinara-agent-${id}-`));
   try {

--- a/scripts/build-feature-packages.mjs
+++ b/scripts/build-feature-packages.mjs
@@ -10,6 +10,7 @@ import { readCatalogFamily, writeCatalogFamily } from "./catalog-lanes.mjs";
 import { assertHierarchicalMapsPrivateImportBoundary } from "./hierarchical-maps-boundary.mjs";
 import { assertPackagePrivateImportBoundary } from "./package-engine-boundary.mjs";
 import { withPackageActivationGuidance } from "./catalog-package-guidance.mjs";
+import { writeEnglishPackageLocale } from "./package-locales.mjs";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const engineRoot = resolve(process.env.MARINARA_ENGINE_ROOT || join(repoRoot, "../Marinara-Engine"));
@@ -1338,6 +1339,7 @@ for (const feature of selectedFeatures) {
     restartRequired: true,
   };
   await writeFile(join(sourceDir, "manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`);
+  await writeEnglishPackageLocale(sourceDir, manifest, [agentDefinition]);
 
   const temporary = await mkdtemp(join(tmpdir(), `marinara-feature-${feature.id}-`));
   try {

--- a/scripts/package-locales.mjs
+++ b/scripts/package-locales.mjs
@@ -1,0 +1,58 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+export const PACKAGE_LOCALE_SCHEMA_REFERENCE = "../../../schemas/package-localization.schema.json";
+
+function localizedPromptTemplates(definition) {
+  if (!Array.isArray(definition.promptTemplates)) return undefined;
+  const entries = definition.promptTemplates
+    .filter((template) => template?.id && (template.name || template.description))
+    .map((template) => [
+      template.id,
+      {
+        ...(template.name ? { name: template.name } : {}),
+        ...(template.description ? { description: template.description } : {}),
+      },
+    ]);
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
+export function buildEnglishPackageLocale(manifest, agentDefinitions) {
+  return {
+    $schema: PACKAGE_LOCALE_SCHEMA_REFERENCE,
+    _meta: {
+      locale: "en",
+      direction: "ltr",
+    },
+    package: {
+      name: manifest.name,
+      description: manifest.description ?? "",
+    },
+    agents: Object.fromEntries(
+      agentDefinitions.map((definition) => {
+        const promptTemplates = localizedPromptTemplates(definition);
+        return [
+          definition.id,
+          {
+            name: definition.name,
+            description: definition.description ?? "",
+            ...(promptTemplates ? { promptTemplates } : {}),
+          },
+        ];
+      }),
+    ),
+  };
+}
+
+export function serializePackageLocale(catalog) {
+  return `${JSON.stringify(catalog, null, 2)}\n`;
+}
+
+export async function writeEnglishPackageLocale(packageRoot, manifest, agentDefinitions) {
+  const localesRoot = join(packageRoot, "locales");
+  await mkdir(localesRoot, { recursive: true });
+  await writeFile(
+    join(localesRoot, "en.json"),
+    serializePackageLocale(buildEnglishPackageLocale(manifest, agentDefinitions)),
+  );
+}

--- a/scripts/package-locales.mjs
+++ b/scripts/package-locales.mjs
@@ -1,7 +1,38 @@
-import { mkdir, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { mkdir, readFile, realpath, writeFile } from "node:fs/promises";
+import { isAbsolute, join, relative, resolve, sep } from "node:path";
 
 export const PACKAGE_LOCALE_SCHEMA_REFERENCE = "../../../schemas/package-localization.schema.json";
+
+export async function readPackageManifest(packageRoot) {
+  try {
+    return JSON.parse(await readFile(join(packageRoot, "manifest.json"), "utf8"));
+  } catch (error) {
+    if (error?.code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+export async function resolvePackageOwnedPath(packageRoot, packagePath, label) {
+  if (typeof packagePath !== "string" || packagePath.trim().length === 0) {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+  const resolvedRoot = await realpath(resolve(packageRoot));
+  const resolvedPath = await realpath(resolve(resolvedRoot, packagePath));
+  const relativePath = relative(resolvedRoot, resolvedPath);
+  if (!relativePath || relativePath === ".." || relativePath.startsWith(`..${sep}`) || isAbsolute(relativePath)) {
+    throw new Error(`${label} must remain inside ${resolvedRoot}`);
+  }
+  return resolvedPath;
+}
+
+export async function readPackageAgentDefinitions(packageRoot, manifest) {
+  const agentsPath = await resolvePackageOwnedPath(
+    packageRoot,
+    manifest.entrypoints?.agents,
+    `${manifest.id ?? packageRoot} Agent entrypoint`,
+  );
+  return JSON.parse(await readFile(agentsPath, "utf8"));
+}
 
 function localizedPromptTemplates(definition) {
   if (!Array.isArray(definition.promptTemplates)) return undefined;
@@ -26,7 +57,7 @@ export function buildEnglishPackageLocale(manifest, agentDefinitions) {
     },
     package: {
       name: manifest.name,
-      description: manifest.description ?? "",
+      ...(manifest.description === undefined ? {} : { description: manifest.description }),
     },
     agents: Object.fromEntries(
       agentDefinitions.map((definition) => {
@@ -35,7 +66,7 @@ export function buildEnglishPackageLocale(manifest, agentDefinitions) {
           definition.id,
           {
             name: definition.name,
-            description: definition.description ?? "",
+            ...(definition.description === undefined ? {} : { description: definition.description }),
             ...(promptTemplates ? { promptTemplates } : {}),
           },
         ];

--- a/scripts/sync-package-locales.mjs
+++ b/scripts/sync-package-locales.mjs
@@ -1,0 +1,59 @@
+import { readFile, readdir } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  buildEnglishPackageLocale,
+  serializePackageLocale,
+  writeEnglishPackageLocale,
+} from "./package-locales.mjs";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const packagesRoot = join(repoRoot, "packages");
+const checkOnly = process.argv.includes("--check");
+const requestedIds = new Set(process.argv.slice(2).filter((argument) => argument !== "--check"));
+const packageIds = (await readdir(packagesRoot, { withFileTypes: true }))
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => entry.name)
+  .filter((id) => requestedIds.size === 0 || requestedIds.has(id))
+  .sort();
+
+if (requestedIds.size > 0 && packageIds.length !== requestedIds.size) {
+  const knownIds = new Set(packageIds);
+  const unknownIds = [...requestedIds].filter((id) => !knownIds.has(id));
+  throw new Error(`Unknown package${unknownIds.length === 1 ? "" : "s"}: ${unknownIds.join(", ")}`);
+}
+
+const drifted = [];
+for (const id of packageIds) {
+  const packageRoot = join(packagesRoot, id);
+  let manifest;
+  try {
+    manifest = JSON.parse(await readFile(join(packageRoot, "manifest.json"), "utf8"));
+  } catch {
+    continue;
+  }
+  if (!manifest.entrypoints?.agents) continue;
+  const agentDefinitions = JSON.parse(await readFile(join(packageRoot, manifest.entrypoints.agents), "utf8"));
+  const expected = serializePackageLocale(buildEnglishPackageLocale(manifest, agentDefinitions));
+
+  if (checkOnly) {
+    const localePath = join(packageRoot, "locales", "en.json");
+    const actual = await readFile(localePath, "utf8").catch(() => "");
+    if (actual !== expected) drifted.push(id);
+    continue;
+  }
+
+  await writeEnglishPackageLocale(packageRoot, manifest, agentDefinitions);
+}
+
+if (drifted.length > 0) {
+  throw new Error(
+    `English package localization catalogs are stale for: ${drifted.join(", ")}. Run node scripts/sync-package-locales.mjs.`,
+  );
+}
+
+console.log(
+  checkOnly
+    ? `Package localization catalogs are synchronized (${packageIds.length} checked).`
+    : `Package localization catalogs synchronized (${packageIds.length} written).`,
+);

--- a/scripts/sync-package-locales.mjs
+++ b/scripts/sync-package-locales.mjs
@@ -3,6 +3,8 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   buildEnglishPackageLocale,
+  readPackageAgentDefinitions,
+  readPackageManifest,
   serializePackageLocale,
   writeEnglishPackageLocale,
 } from "./package-locales.mjs";
@@ -26,14 +28,10 @@ if (requestedIds.size > 0 && packageIds.length !== requestedIds.size) {
 const drifted = [];
 for (const id of packageIds) {
   const packageRoot = join(packagesRoot, id);
-  let manifest;
-  try {
-    manifest = JSON.parse(await readFile(join(packageRoot, "manifest.json"), "utf8"));
-  } catch {
-    continue;
-  }
+  const manifest = await readPackageManifest(packageRoot);
+  if (!manifest) continue;
   if (!manifest.entrypoints?.agents) continue;
-  const agentDefinitions = JSON.parse(await readFile(join(packageRoot, manifest.entrypoints.agents), "utf8"));
+  const agentDefinitions = await readPackageAgentDefinitions(packageRoot, manifest);
   const expected = serializePackageLocale(buildEnglishPackageLocale(manifest, agentDefinitions));
 
   if (checkOnly) {

--- a/scripts/validate-package-locales.mjs
+++ b/scripts/validate-package-locales.mjs
@@ -1,0 +1,126 @@
+import { readFile, readdir } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  buildEnglishPackageLocale,
+  PACKAGE_LOCALE_SCHEMA_REFERENCE,
+  serializePackageLocale,
+} from "./package-locales.mjs";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const packagesRoot = join(repoRoot, "packages");
+const localePattern = /^[a-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$/u;
+const topLevelKeys = new Set(["$schema", "_meta", "package", "agents"]);
+const metadataKeys = new Set(["locale", "direction"]);
+const localizedTextKeys = new Set(["name", "description"]);
+const localizedAgentKeys = new Set(["name", "description", "promptTemplates"]);
+
+function assertRecord(value, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+}
+
+function assertOnlyKeys(value, allowed, label) {
+  for (const key of Object.keys(value)) {
+    if (!allowed.has(key)) throw new Error(`${label} contains unsupported key ${key}`);
+  }
+}
+
+function assertLocalizedText(value, label) {
+  assertRecord(value, label);
+  assertOnlyKeys(value, localizedTextKeys, label);
+  for (const [key, text] of Object.entries(value)) {
+    if (typeof text !== "string" || text.trim().length === 0) {
+      throw new Error(`${label}.${key} must be a non-empty string`);
+    }
+  }
+}
+
+function validateLocaleCatalog(catalog, { id, locale, agentDefinitions }) {
+  const label = `${id} ${locale} localization`;
+  assertRecord(catalog, label);
+  assertOnlyKeys(catalog, topLevelKeys, label);
+  if (catalog.$schema !== PACKAGE_LOCALE_SCHEMA_REFERENCE) {
+    throw new Error(`${label} must reference ${PACKAGE_LOCALE_SCHEMA_REFERENCE}`);
+  }
+  assertRecord(catalog._meta, `${label} metadata`);
+  assertOnlyKeys(catalog._meta, metadataKeys, `${label} metadata`);
+  if (catalog._meta.locale !== locale) {
+    throw new Error(`${label} metadata locale must match its filename`);
+  }
+  if (!localePattern.test(locale)) throw new Error(`${label} uses an invalid locale tag`);
+  if (!new Set(["ltr", "rtl"]).has(catalog._meta.direction)) {
+    throw new Error(`${label} direction must be ltr or rtl`);
+  }
+  if (catalog.package !== undefined) assertLocalizedText(catalog.package, `${label} package`);
+  if (catalog.agents === undefined) return;
+
+  assertRecord(catalog.agents, `${label} agents`);
+  const definitionsById = new Map(agentDefinitions.map((definition) => [definition.id, definition]));
+  for (const [agentId, localizedAgent] of Object.entries(catalog.agents)) {
+    const definition = definitionsById.get(agentId);
+    if (!definition) throw new Error(`${label} references unknown Agent ${agentId}`);
+    assertRecord(localizedAgent, `${label} Agent ${agentId}`);
+    assertOnlyKeys(localizedAgent, localizedAgentKeys, `${label} Agent ${agentId}`);
+    for (const key of ["name", "description"]) {
+      if (localizedAgent[key] !== undefined) {
+        assertLocalizedText({ [key]: localizedAgent[key] }, `${label} Agent ${agentId}`);
+      }
+    }
+    if (localizedAgent.promptTemplates === undefined) continue;
+    assertRecord(localizedAgent.promptTemplates, `${label} Agent ${agentId} prompt templates`);
+    const templateIds = new Set((definition.promptTemplates ?? []).map((template) => template.id));
+    for (const [templateId, localizedTemplate] of Object.entries(localizedAgent.promptTemplates)) {
+      if (!templateIds.has(templateId)) {
+        throw new Error(`${label} Agent ${agentId} references unknown prompt template ${templateId}`);
+      }
+      assertLocalizedText(localizedTemplate, `${label} Agent ${agentId} prompt template ${templateId}`);
+    }
+  }
+}
+
+let packageCount = 0;
+let translationCount = 0;
+for (const entry of (await readdir(packagesRoot, { withFileTypes: true })).sort((left, right) =>
+  left.name.localeCompare(right.name),
+)) {
+  if (!entry.isDirectory()) continue;
+  const packageRoot = join(packagesRoot, entry.name);
+  let manifest;
+  try {
+    manifest = JSON.parse(await readFile(join(packageRoot, "manifest.json"), "utf8"));
+  } catch {
+    continue;
+  }
+  if (!manifest.entrypoints?.agents) continue;
+  const agentDefinitions = JSON.parse(await readFile(join(packageRoot, manifest.entrypoints.agents), "utf8"));
+  const localesRoot = join(packageRoot, "locales");
+  const localeFiles = (await readdir(localesRoot, { withFileTypes: true }).catch(() => []))
+    .filter((localeEntry) => localeEntry.isFile() && localeEntry.name.endsWith(".json"))
+    .map((localeEntry) => localeEntry.name)
+    .sort();
+  if (!localeFiles.includes("en.json")) {
+    throw new Error(`Missing canonical English localization for ${manifest.id}`);
+  }
+
+  const expectedEnglish = serializePackageLocale(buildEnglishPackageLocale(manifest, agentDefinitions));
+  const actualEnglish = await readFile(join(localesRoot, "en.json"), "utf8");
+  if (actualEnglish !== expectedEnglish) {
+    throw new Error(
+      `English localization for ${manifest.id} is stale. Run node scripts/sync-package-locales.mjs.`,
+    );
+  }
+
+  for (const localeFile of localeFiles) {
+    const locale = localeFile.slice(0, -".json".length);
+    const catalog = JSON.parse(await readFile(join(localesRoot, localeFile), "utf8"));
+    validateLocaleCatalog(catalog, { id: manifest.id, locale, agentDefinitions });
+    if (locale !== "en") translationCount += 1;
+  }
+  packageCount += 1;
+}
+
+console.log(
+  `Package localization catalogs valid: ${packageCount} canonical English catalogs, ${translationCount} translations.`,
+);

--- a/scripts/validate-package-locales.mjs
+++ b/scripts/validate-package-locales.mjs
@@ -4,6 +4,8 @@ import { fileURLToPath } from "node:url";
 import {
   buildEnglishPackageLocale,
   PACKAGE_LOCALE_SCHEMA_REFERENCE,
+  readPackageAgentDefinitions,
+  readPackageManifest,
   serializePackageLocale,
 } from "./package-locales.mjs";
 
@@ -87,14 +89,10 @@ for (const entry of (await readdir(packagesRoot, { withFileTypes: true })).sort(
 )) {
   if (!entry.isDirectory()) continue;
   const packageRoot = join(packagesRoot, entry.name);
-  let manifest;
-  try {
-    manifest = JSON.parse(await readFile(join(packageRoot, "manifest.json"), "utf8"));
-  } catch {
-    continue;
-  }
+  const manifest = await readPackageManifest(packageRoot);
+  if (!manifest) continue;
   if (!manifest.entrypoints?.agents) continue;
-  const agentDefinitions = JSON.parse(await readFile(join(packageRoot, manifest.entrypoints.agents), "utf8"));
+  const agentDefinitions = await readPackageAgentDefinitions(packageRoot, manifest);
   const localesRoot = join(packageRoot, "locales");
   const localeFiles = (await readdir(localesRoot, { withFileTypes: true }).catch(() => []))
     .filter((localeEntry) => localeEntry.isFile() && localeEntry.name.endsWith(".json"))


### PR DESCRIPTION
## Linked issue

Closes #270

## Why this change

Downloadable Agent names, descriptions, and named prompt options are package-owned English strings with no canonical translation source. Contributors need stable, reviewable locale files before Korean or other translations can be prepared.

## What changed

- Added `packages/<id>/locales/en.json` for all 31 downloadable packages.
- Covered package and installed-Agent names/descriptions plus user-visible named prompt-option labels; model instructions remain deliberately untranslated.
- Added a shared JSON schema, deterministic sync helper, and validation for English parity, BCP 47 locale filenames, partial translations, stable Agent IDs, and stable prompt-template IDs.
- Wired catalog builders to refresh canonical English catalogs and added localization validation to pull-request CI.
- Documented the package/Engine boundary and the workflow for a Korean or other locale contribution.

## Package and security impact

- Affected package IDs: all downloadable catalog packages
- Permissions, entrypoints, runtime behavior, and Engine compatibility: unchanged
- Artifacts and catalog lanes: unchanged; these repository-owned translation sources are not included in package archives yet
- Engine integration: a separate Engine change will be required before **Agents → Download Agents** consumes localized metadata

## Automated evidence

- `node scripts/sync-package-locales.mjs --check`
- `node scripts/validate-package-locales.mjs`
- `node scripts/test-catalog-lanes.mjs`
- `node scripts/validate-catalog.mjs`
- `node --check` for the three new scripts
- `git diff --check`

All commands passed locally. Catalog validation still reports 31 packages (22 agents and 9 features) in both v2 and v3 lanes.

## Validation checklist

- [ ] Installed or updated affected packages through Marinara Engine
- [ ] Checked supported modes, restart behavior, and uninstall cleanup
- [ ] Read and followed `CONTRIBUTING.md`

Manual package installation is not required for this metadata-only preparation because no archive, manifest, catalog entry, executable payload, or Engine runtime changed. Checklist boxes remain unchecked for human verification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added English localization catalogs for package names, descriptions, agent details, and supported prompt templates.
  * Added structured localization support for package metadata, including locale and text-direction information.
* **Documentation**
  * Documented package localization sources, translation guidelines, English fallback behavior, and contribution requirements.
* **Validation**
  * Added automated checks to detect missing, invalid, or outdated localization catalogs and keep generated translations consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->