### PR TITLE
Remove unused Noodle persona assignment

### DIFF
--- a/tests/package-noodle.e2e.ts
+++ b/tests/package-noodle.e2e.ts
@@ -1788,7 +1788,6 @@ test.describe("package-owned Noodle interface", () => {
         );
         expect(personaResponse.ok()).toBe(true);
         const createdPersona = (await personaResponse.json()) as { id: string };
-        personaId = createdPersona.id;
         createdPersonaId = createdPersona.id;
         const activateResponse = await page.request.put(
           `/api/characters/personas/${createdPersona.id}/activate`,


### PR DESCRIPTION
# Pull request

> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.

## Linked issue

Closes #331

## Why this change

- The final v2.4.2 native Code Quality pass found an assignment in the Noodle mention-autocomplete browser regression whose value is never read.

## What changed

- Remove only the redundant `personaId` assignment after creating a temporary persona.
- Keep the created ID used for cleanup and keep activation behavior unchanged.

## Package and security impact

- Affected package IDs: none; test-only change.
- Engine compatibility impact: none.
- New or changed permissions/entrypoints: none.
- Restart, storage, update, or uninstall impact: none.

## Validation

- [ ] `node scripts/validate-catalog.mjs` passes locally
- [ ] `git diff --check` passes locally
- [ ] Rebuilt every affected manifest, payload, artifact, and catalog entry
- [ ] Installed or updated the affected package through Marinara Engine
- [ ] Checked supported modes, restart behavior, and uninstall cleanup
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- CI must run the complete Noodle browser suite.
- The edit removes an unused assignment only; persona creation, activation, and cleanup still use `createdPersona.id` / `createdPersonaId`.

## Documentation impact

- [ ] No documentation changes needed
- [ ] Updated this README catalog and package guidance
- [ ] Updated linked Marinara Engine documentation

## UI evidence (if applicable)

- No UI change; test-only cleanup.