### PR TITLE
build: pin LF via .gitattributes and verify manifest bytes for every package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,54 @@
+# Line endings are part of this repository's build contract, not a preference.
+#
+# Package builders raw-concatenate `src/*.js` into `client.js`, and each
+# manifest records the exact `bytes` and `sha256` of every declared file. A
+# working copy smudged to CRLF therefore inflates every built payload and
+# poisons the manifest hashes: pixelforge 0.11.0 shipped a manifest, artifact
+# zip, and source blob that disagreed by 3,280 bytes because one source file
+# sat CRLF at build time (caught in #544). The same smudge makes
+# validate-catalog.mjs and validate-package-locales.mjs fail on packages a
+# contributor never touched.
+#
+# Git for Windows writes `core.autocrlf=true` into the SYSTEM gitconfig, so a
+# fresh clone is already smudged before anyone can configure a repo-local
+# setting. These rules travel with the tree and win over that default.
+
+# Everything git detects as text checks out LF on every platform.
+* text=auto eol=lf
+
+# Binary payloads are pinned explicitly instead of relying on git's NUL-byte
+# heuristic. The heuristic only inspects the head of a file, and an archive or
+# image that slips through it and gets EOL-converted is silent, unrecoverable
+# corruption — a cost far above the price of listing the extensions.
+#
+# `git check-attr` reports `eol: lf` on these paths too, inherited from the `*`
+# line above. It is inert: `binary` unsets `text`, and git only runs EOL
+# conversion on paths whose `text` attribute is set or auto-detected.
+
+# Committed package artifacts.
+*.zip binary
+
+# Catalog artwork, tilesheets, and sprites. `.png` is the only image format in
+# the tree today; the rest are the formats validate-catalog.mjs already accepts
+# for package assets and Home browser-tab icons, pinned before one lands.
+*.gif  binary
+*.ico  binary
+*.jpeg binary
+*.jpg  binary
+*.png  binary
+*.webp binary
+
+# Fonts, audio, and documents. Not present today — listed so that adding one is
+# not also a corruption bug.
+*.mp3   binary
+*.ogg   binary
+*.otf   binary
+*.pdf   binary
+*.ttf   binary
+*.wav   binary
+*.woff  binary
+*.woff2 binary
+
+# No Windows-native scripts (.bat, .cmd, .ps1) exist in this tree, so nothing
+# is pinned to CRLF. Add `eol=crlf` alongside the first one that lands —
+# cmd.exe and PowerShell expect CRLF in scripts they execute.

--- a/scripts/package-manifest-integrity.mjs
+++ b/scripts/package-manifest-integrity.mjs
@@ -1,0 +1,161 @@
+// Manifest integrity for every package in the tree, not just the listed ones.
+//
+// validate-catalog.mjs walks `catalog.packages`, so a package held back by
+// INCOMPLETE_PACKAGE_IDS (scripts/catalog-incomplete.mjs) is in no catalog and
+// was therefore never reached by any byte check. That is how pixelforge 0.11.0
+// shipped a commit whose manifest, artifact zip, and source file disagreed
+// about client.js by 3,280 bytes — one source file had been built while it sat
+// CRLF on disk (#544, #545).
+//
+// The per-file assertions live here rather than inline in the catalog loop so
+// the listed and held-back paths run the identical check and cannot drift.
+import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
+import { readFile, readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import {
+  assertPortableFilenameComponent,
+  assertPortableRelativePath,
+  packageArtifactName,
+  resolveContainedPortablePath,
+} from "./catalog-path-safety.mjs";
+
+export function readZip(args, { packageId, artifactPath, member = null, purpose }) {
+  const result = spawnSync("unzip", args, {
+    encoding: member ? undefined : "utf8",
+    maxBuffer: 120 * 1024 * 1024,
+  });
+  if (result.error?.code === "ENOENT") {
+    throw new Error(
+      `Cannot ${purpose} ${packageId} artifact ${artifactPath}: unzip executable was not found; install unzip and retry`,
+    );
+  }
+  if (result.status !== 0) {
+    const detail = result.stderr?.toString().trim() || result.error?.message || `exit status ${result.status}`;
+    throw new Error(
+      `Could not ${purpose} ${member ? `member ${member} from ` : ""}${packageId} artifact ${artifactPath}: ${detail}`,
+    );
+  }
+  return result;
+}
+
+// The #544 invariant: every file the manifest declares must weigh and hash
+// exactly what the manifest says, both as the source file on disk and as the
+// member committed inside the artifact, and those two must be byte-identical.
+// A CRLF-smudged source trips this on the first `bytes` comparison.
+export async function assertDeclaredFilesMatchManifest({ manifest, packageRoot, artifactPath }) {
+  for (const declared of manifest.files) {
+    const sourcePayload = await readFile(
+      await resolveContainedPortablePath(packageRoot, declared.path, `Declared file for ${manifest.id}`),
+    );
+    const payloads = [["source", sourcePayload]];
+    let archivedPayload = null;
+    if (artifactPath) {
+      archivedPayload = readZip(["-p", artifactPath, declared.path], {
+        packageId: manifest.id,
+        artifactPath,
+        member: declared.path,
+        purpose: "read",
+      }).stdout;
+      payloads.push(["artifact", archivedPayload]);
+    }
+    for (const [location, payload] of payloads) {
+      if (payload.byteLength !== declared.bytes) {
+        throw new Error(
+          `${manifest.id} ${declared.path} ${location} size does not match its manifest ` +
+            `(manifest ${declared.bytes} bytes, ${location} ${payload.byteLength} bytes)`,
+        );
+      }
+      if (createHash("sha256").update(payload).digest("hex") !== declared.sha256) {
+        throw new Error(`${manifest.id} ${declared.path} ${location} hash does not match its manifest`);
+      }
+    }
+    if (archivedPayload && !sourcePayload.equals(archivedPayload)) {
+      throw new Error(`${manifest.id} ${declared.path} differs between package source and artifact`);
+    }
+  }
+}
+
+// Verifies the artifact describes the same file set as the manifest, and that
+// the manifest sealed inside the zip is the manifest on disk.
+function assertArtifactMatchesManifest({ manifest, artifactPath }) {
+  const listed = readZip(["-Z1", artifactPath], {
+    packageId: manifest.id,
+    artifactPath,
+    purpose: "inspect",
+  });
+  const actualFiles = listed.stdout
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((path) => assertPortableRelativePath(path, `Archived file for ${manifest.id}`))
+    .sort();
+  const declaredFiles = ["manifest.json", ...manifest.files.map((file) => file.path)].sort();
+  if (JSON.stringify(actualFiles) !== JSON.stringify(declaredFiles)) {
+    throw new Error(`Artifact file list mismatch for ${manifest.id}`);
+  }
+  const archivedManifest = readZip(["-p", artifactPath, "manifest.json"], {
+    packageId: manifest.id,
+    artifactPath,
+    member: "manifest.json",
+    purpose: "read",
+  });
+  if (JSON.stringify(JSON.parse(archivedManifest.stdout.toString("utf8"))) !== JSON.stringify(manifest)) {
+    throw new Error(`Archived manifest does not match packages/${manifest.id}/manifest.json`);
+  }
+}
+
+// Covers the packages the catalog loop never reaches. `cataloguedIds` are the
+// ids validate-catalog.mjs already verified in full, so each package directory
+// is checked exactly once by exactly one path.
+export async function assertEveryPackageManifestIntegrity({ repoRoot, cataloguedIds }) {
+  const packagesRoot = join(repoRoot, "packages");
+  const artifactsRoot = join(repoRoot, "artifacts");
+  const entries = await readdir(packagesRoot, { withFileTypes: true });
+  const checked = [];
+  const withoutArtifact = [];
+  for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+    if (!entry.isDirectory()) continue;
+    assertPortableFilenameComponent(entry.name, "Package directory");
+    const packageRoot = await resolveContainedPortablePath(
+      packagesRoot,
+      entry.name,
+      `Package directory for ${entry.name}`,
+    );
+    const manifestPath = join(packageRoot, "manifest.json");
+    if (!existsSync(manifestPath)) {
+      throw new Error(`packages/${entry.name} has no manifest.json`);
+    }
+    const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+    if (manifest.id !== entry.name) {
+      throw new Error(`packages/${entry.name}/manifest.json declares id ${manifest.id}`);
+    }
+    if (cataloguedIds.has(manifest.id)) continue;
+    if (!Array.isArray(manifest.files)) {
+      throw new Error(`Missing file declarations for ${manifest.id}`);
+    }
+    const declaredPaths = new Set();
+    for (const [index, declared] of manifest.files.entries()) {
+      const declaredPath = assertPortableRelativePath(declared?.path, `Declared file ${index + 1} for ${manifest.id}`);
+      if (declaredPaths.has(declaredPath)) {
+        throw new Error(`Duplicate declared file ${declaredPath} for ${manifest.id}`);
+      }
+      declaredPaths.add(declaredPath);
+    }
+    // A held-back package need not have been built yet, but when its artifact
+    // is committed the artifact is held to the same contract as a listed one.
+    const artifactName = packageArtifactName(manifest.id, manifest.version);
+    const candidateArtifactPath = join(artifactsRoot, artifactName);
+    let artifactPath = null;
+    if (existsSync(candidateArtifactPath)) {
+      artifactPath = await resolveContainedPortablePath(artifactsRoot, artifactName, `Artifact for ${manifest.id}`);
+      assertArtifactMatchesManifest({ manifest, artifactPath });
+    } else {
+      withoutArtifact.push(manifest.id);
+    }
+    await assertDeclaredFilesMatchManifest({ manifest, packageRoot, artifactPath });
+    checked.push(manifest.id);
+  }
+  return { checked, withoutArtifact };
+}

--- a/scripts/package-manifest-integrity.mjs
+++ b/scripts/package-manifest-integrity.mjs
@@ -116,6 +116,15 @@ export async function assertEveryPackageManifestIntegrity({ repoRoot, catalogued
   const checked = [];
   const withoutArtifact = [];
   for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+    // `readdir` describes the entry itself, not its target, so a symlinked
+    // package directory reports isDirectory() === false and the skip below
+    // would drop it from the sweep without a word — the same silent-gap
+    // failure this sweep exists to close. Reject rather than follow: a package
+    // is a real directory in this tree, and following the link would make
+    // coverage depend on core.symlinks, which Git for Windows sets to false.
+    if (entry.isSymbolicLink()) {
+      throw new Error(`packages/${entry.name} is a symbolic link; packages must be real directories`);
+    }
     if (!entry.isDirectory()) continue;
     assertPortableFilenameComponent(entry.name, "Package directory");
     const packageRoot = await resolveContainedPortablePath(

--- a/scripts/validate-catalog.mjs
+++ b/scripts/validate-catalog.mjs
@@ -16,6 +16,11 @@ import { assertHierarchicalMapsPrivateImportBoundary } from "./hierarchical-maps
 import { INCOMPLETE_PACKAGE_IDS, STAGING_ONLY_PACKAGE_IDS } from "./catalog-incomplete.mjs";
 import { assertPackagePrivateImportBoundary } from "./package-engine-boundary.mjs";
 import {
+  assertDeclaredFilesMatchManifest,
+  assertEveryPackageManifestIntegrity,
+  readZip,
+} from "./package-manifest-integrity.mjs";
+import {
   OFFICIAL_PACKAGE_GUIDANCE,
   withPackageActivationGuidance,
   withoutPackageActivationGuidance,
@@ -257,25 +262,6 @@ function assertLocalizedField(value, maximum, label) {
       `${label} does not match capability API ${ENGINE_CAPABILITY_API.major}.${ENGINE_CAPABILITY_API.minor}`,
     );
   }
-}
-
-function readZip(args, { packageId, artifactPath, member = null, purpose }) {
-  const result = spawnSync("unzip", args, {
-    encoding: member ? undefined : "utf8",
-    maxBuffer: 120 * 1024 * 1024,
-  });
-  if (result.error?.code === "ENOENT") {
-    throw new Error(
-      `Cannot ${purpose} ${packageId} artifact ${artifactPath}: unzip executable was not found; install unzip and retry`,
-    );
-  }
-  if (result.status !== 0) {
-    const detail = result.stderr?.toString().trim() || result.error?.message || `exit status ${result.status}`;
-    throw new Error(
-      `Could not ${purpose} ${member ? `member ${member} from ` : ""}${packageId} artifact ${artifactPath}: ${detail}`,
-    );
-  }
-  return result;
 }
 
 async function validateTurnGameRuntime(manifest, packageRoot) {
@@ -588,31 +574,7 @@ for (const entry of catalog.packages) {
       throw new Error(`Unsupported Home browser tab icon format ${iconPath} for ${manifest.id}`);
     }
   }
-  for (const declared of manifest.files) {
-    const sourcePayload = await readFile(
-      await resolveContainedPortablePath(packageRoot, declared.path, `Declared file for ${manifest.id}`),
-    );
-    const archivedPayload = readZip(["-p", artifactPath, declared.path], {
-      packageId: manifest.id,
-      artifactPath,
-      member: declared.path,
-      purpose: "read",
-    });
-    for (const [location, payload] of [
-      ["source", sourcePayload],
-      ["artifact", archivedPayload.stdout],
-    ]) {
-      if (payload.byteLength !== declared.bytes) {
-        throw new Error(`${manifest.id} ${declared.path} ${location} size does not match its manifest`);
-      }
-      if (createHash("sha256").update(payload).digest("hex") !== declared.sha256) {
-        throw new Error(`${manifest.id} ${declared.path} ${location} hash does not match its manifest`);
-      }
-    }
-    if (!sourcePayload.equals(archivedPayload.stdout)) {
-      throw new Error(`${manifest.id} ${declared.path} differs between package source and artifact`);
-    }
-  }
+  await assertDeclaredFilesMatchManifest({ manifest, packageRoot, artifactPath });
 
   for (const entrypoint of [manifest.entrypoints.server, manifest.entrypoints.client].filter(Boolean)) {
     const syntax = spawnSync(
@@ -810,6 +772,12 @@ for (const entry of catalog.packages) {
   }
 }
 
+// The loop above only ever sees `catalog.packages`, so a package held out of
+// every catalog by INCOMPLETE_PACKAGE_IDS had no byte check at all — which is
+// how pixelforge shipped a manifest, artifact, and source that disagreed
+// (#544). Sweep the rest of packages/ with the same assertions.
+const uncataloguedIntegrity = await assertEveryPackageManifestIntegrity({ repoRoot, cataloguedIds: ids });
+
 // Guidance may be authored ahead of listing for an incomplete package (its id
 // is absent from the catalog by design), so exempt those ids from exactness.
 const guidanceIds = Object.keys(OFFICIAL_PACKAGE_GUIDANCE)
@@ -827,6 +795,13 @@ if (publishedCatalog.packages.length !== 36 || agentOnly !== 24 || features !== 
   throw new Error(`Expected 24 agents and 12 features, found ${agentOnly} and ${features}`);
 }
 console.log(`Catalog valid: ${publishedCatalog.packages.length} packages (${agentOnly} agents, ${features} features).`);
+if (uncataloguedIntegrity.checked.length > 0) {
+  const withoutArtifact = uncataloguedIntegrity.withoutArtifact;
+  console.log(
+    `Uncatalogued package manifests valid: ${uncataloguedIntegrity.checked.join(", ")}` +
+      `${withoutArtifact.length > 0 ? ` (source only, no committed artifact: ${withoutArtifact.join(", ")})` : ""}.`,
+  );
+}
 if (previewCatalog.packages.length > 0) {
   console.log(
     `Preview overlay valid: ${previewCatalog.packages.length} staging-only package(s) (${previewCatalog.packages


### PR DESCRIPTION
# Pull request

> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.

## Linked issue

Closes #545

## Why this change

- Git for Windows writes `core.autocrlf=true` into the **system** gitconfig, so a fresh clone on Windows is CRLF-smudged before any repo-local setting can help. This repo's builds raw-concatenate `src/*.js` and its manifests record exact bytes/sha256, so the smudge has already caused a shipped defect: pixelforge 0.11.0's manifest, artifact zip, and source blob disagreed by 3,280 bytes because one source file sat CRLF at build time (caught in #544 review). The same smudge makes `validate-catalog.mjs` and `validate-package-locales.mjs` fail on packages a contributor never touched. And the byte-equality check that enforces exactly this invariant only walked `catalog.packages` — so `INCOMPLETE_PACKAGE_IDS` members (pixelforge) were never checked at all, which is how the broken commit shipped.

## What changed

- **Root `.gitattributes`** (new): `* text=auto eol=lf` as the base — `eol` travels with the tree and wins over any `core.autocrlf` — plus explicit `binary` pins for the 272 committed `.zip` artifacts, `.png` (the only image format in the tree today), the other image formats `validate-catalog.mjs` already accepts (pinned before one lands), and defensive audio/font/pdf rules. No `eol=crlf` rules: the repo contains no Windows-native scripts (documented in a comment). **No renormalization was needed**: all 1,282 text blobs at HEAD are already pure LF and all 323 binaries are `-text`, triple-verified (`git ls-files --eol`, a per-blob `cat-file` scan, and `git add --renormalize .` staging zero changes) — so this PR changes checkout behavior only, not one byte of content.
- **`scripts/package-manifest-integrity.mjs`** (new) + **`validate-catalog.mjs`** rewired: the per-file bytes/sha256 assertions and `readZip` move into a shared module used by *both* the existing catalog loop and a new sweep over every `packages/*/manifest.json` the catalog misses — identical code on both paths, so they cannot drift. Catalog-excluded packages now get the same source-vs-manifest and artifact-vs-manifest verification as everything else. CI already runs `validate-catalog.mjs`, so no workflow change is needed.
- Affected package IDs: none — no package source or artifact is modified.

## Package and security impact

- Affected package IDs: none (infrastructure only)
- Engine compatibility impact: none
- New or changed permissions/entrypoints: none
- Restart, storage, update, or uninstall impact: none

## Validation

<!-- These are human tasks. Never tick a box for a check that was not actually performed. -->

- [ ] `node scripts/validate-catalog.mjs` passes locally
- [ ] `git diff --check` passes locally
- [ ] Rebuilt every affected manifest, payload, artifact, and catalog entry
- [ ] Installed or updated the affected package through Marinara Engine
- [ ] Checked supported modes, restart behavior, and uninstall cleanup
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Boxes left for the human contributor per the template. What was agent-verified, exactly:

- **The smudged-clone before/after** (the heart of it): a `git clone --local -c core.autocrlf=true` of the branch **parent** checks out 1,282 files as CRLF and fails `validate-package-locales` (stale-size error on `background`) and `validate-catalog` (byte mismatch on `eightball`) on the raw tree; the identical clone of **this branch** checks out everything LF (`w/lf` 1,284 / `w/-text` 323, zero CRLF), all validators exit 0, and all 323 binaries are byte-identical to their blobs (`pixelforge-0.11.0.zip` disk = blob).
- **Fail-first on the #544 bug shape**: in a scratch clone, one source file inflated to CRLF (+3,280 bytes — the issue's exact figure) and rebuilt: the **pre-change validator exits 0 on the defect**; the new one exits 1 naming the file and both byte counts ("pixelforge client.js source size does not match its manifest (manifest 625663 bytes, source 622383 bytes)"). The artifact arm proven separately (swapped-in stale zip → "Archived manifest does not match").
- Full gates on the committed tree: `npm run check` (pinned prettier 3.9.6 + eslint 10.8.1) 0 errors; `validate-catalog` / `validate-package-locales` / `test-catalog-lanes` / `validate-pr-triage` all exit 0; `git diff --check` clean.
- Known pre-existing, untouched: `npm run test:security` fails on Windows only (`catalog-path-safety.regression.mjs` asserts a POSIX-shaped path); identical on the unmodified parent; CI runs ubuntu.
- No package was rebuilt or reinstalled — nothing in this PR changes any package's bytes (verified: renormalize staged zero changes).

## Documentation impact

- [x] No documentation changes needed — the `.gitattributes` carries its own rationale as comments where the next contributor will meet it
- [ ] Updated this README catalog and package guidance
- [ ] Updated linked Marinara Engine documentation

## UI evidence (if applicable)

- Not applicable — no UI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized text file line endings across supported environments.
  * Marked binary files to prevent unintended line-ending conversion.
  * Added comprehensive package integrity checks for manifests, files, archives, sizes, hashes, and content consistency.
  * Improved catalog validation by detecting uncatalogued or incomplete packages and clearly reporting source-only packages.
  * Consolidated validation behavior for more consistent and reliable results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->