### PR TITLE
Pixelforge harness: a failing run always leaves — watchdog for the park class, bound for the sync child

### DIFF
--- a/packages/pixelforge/test-brief.mjs
+++ b/packages/pixelforge/test-brief.mjs
@@ -13843,7 +13843,9 @@ await withSavePath(async ({ calls, behavior, makeCore }) => {
            Object.values(w.zones).map((zone) => [zone.id, zone.ground, zone.object, [...zone.solid], zone.features]),
          )).digest("hex"));`,
       ],
-      { encoding: "utf8" },
+      // Bounded, or a hung child blocks this SYNCHRONOUS call where no watchdog
+      // timer can fire — the one hang class the deadline above cannot break.
+      { encoding: "utf8", timeout: 60_000 },
     );
     assert.equal(child.status, 0, `the second interpreter compiled it too (${child.stderr})`);
     assert.equal(child.stdout, mine, "a fresh process compiles the same tiles, the same solidity and the same rows");

--- a/packages/pixelforge/test-brief.mjs
+++ b/packages/pixelforge/test-brief.mjs
@@ -9,6 +9,36 @@ import { readdirSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
+// ── THE HARNESS ALWAYS LEAVES (Agents #554) ──────────────────────────────────
+// A red run was once seen to print an error and then sit past a ten-minute
+// timeout; six later attempts could not reproduce it. What those attempts did
+// settle is that the THROW path is not the one that needs a guard: node prints
+// an uncaught AssertionError and exits 1 in the same tick, with timers armed or
+// not, so a final catch here could only take node's own rendering of the red
+// away from the workflow that reads it, and buy nothing back.
+//
+// The shape that can sit forever is the one that never throws. withSavePath
+// stubs globalThis.setTimeout to RECORD rather than fire, six of the HUD cases
+// stub it away outright, and two package paths — 60-save's brief-storage ladder
+// and 58-player's quarantine one — wait on a promise that only a timer resolves.
+// A case that reaches one of those parks its await, the module promise never
+// settles, and node cannot report what nobody threw. With the loop drained it
+// says so and exits 13; with anything still alive it simply waits, which is a
+// hang with an error printed above it and no exit under it — the report exactly.
+//
+// So the guarantee is a deadline rather than a catch. The timer is unref'd on
+// purpose: it cannot hold a healthy run open (a green run takes ~5s and is long
+// gone before this comes due), and it can only fire inside a process that is
+// still alive at the deadline, which is the hang and nothing else. It prints
+// what the issue asked the next person to capture before killing it.
+const HANG_BUDGET_MS = 120_000; // ~25x a green run; raise it if you are sitting in a debugger
+const watchdog = setTimeout(() => {
+  console.error(`\nharness watchdog: ${HANG_BUDGET_MS}ms and no exit — a case is parked (Agents #554).`);
+  console.error("still alive:", process.getActiveResourcesInfo());
+  process.exit(1);
+}, HANG_BUDGET_MS);
+watchdog.unref();
+
 const here = dirname(fileURLToPath(import.meta.url));
 // Mirror the real bundle: concatenate the modules into one scope (the prelude
 // declares `const PF` itself) and return PF. 70-hud and 80-setup ride along


### PR DESCRIPTION
# Pull request

> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.

## Linked issue

Closes #554

## Why this change

- #554 reported the pixelforge harness hanging after printing an assertion failure. The hang was observed once and never reproduced (six adversarial attempts all exited promptly — see the issue thread), so this PR takes the issue's own endorsed resolution: make the acceptance bar — *any failing run exits non-zero within a bounded time; passing behavior unchanged* — true **by construction**, mooting the unconfirmed incident.
- Investigation for this fix identified the hang class that actually fits the reported symptom, and it is not the throw path: node force-exits an uncaught `AssertionError` in the same tick, stray timers or not (measured). The shape that hangs is a **parked await under stubbed timers**: several lanes stub `globalThis.setTimeout` to record rather than fire, while two package paths await real backoff timers — a case that reaches one parks forever, printing nothing, with any live handle holding the loop open. Reproduced: at `staging` the staged park outlives a 150s kill bound; with this fix it exits 1 at the 120s deadline with diagnostics.

## What changed

- Affected package IDs: none shipped — `packages/pixelforge/test-brief.mjs` only (the manual regression harness; no `src/` change, no artifact rebuild).
- A single **unref'd 120s watchdog** armed at module load, before any lane can swap the timer globals (it holds an already-armed `Timeout`, so the stubbing lanes cannot disarm it). `unref()` is what keeps the green path untouchable — proven load-bearing by negative control. On firing: diagnostic naming #554, `process.getActiveResourcesInfo()`, exit 1. It adds zero output and zero exit-path changes to a green run (output diffed identical modulo line numbers; runtime 0.96× baseline).
- The one hang class a watchdog timer cannot reach — the **synchronous** `spawnSync` child in the cross-process determinism case — gets its own `timeout: 60_000`, converting a hung child into a red instead of a block.
- An uncaught-exception handler was considered and **rejected on measurement**: it buys no exit promptness and costs node's verbatim red rendering, which the fail-first workflow depends on.

## Package and security impact

- Affected package IDs: none (test harness only)
- Engine compatibility impact: none
- New or changed permissions/entrypoints: none
- Restart, storage, update, or uninstall impact: none

## Validation

<!-- These are human tasks. Never tick a box for a check that was not actually performed. -->

- [ ] `node scripts/validate-catalog.mjs` passes locally
- [ ] `git diff --check` passes locally
- [ ] Rebuilt every affected manifest, payload, artifact, and catalog entry
- [ ] Installed or updated the affected package through Marinara Engine
- [ ] Checked supported modes, restart behavior, and uninstall cleanup
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Boxes are the human contributor's list. Agent-verified, independently replayed by a second adversarial agent:

- Forced assertion failures at four depths (early / mid-save-path / post-HUD-state / end): all exit 1 within 2.6s, red output byte-identical to staging's modulo line numbers.
- Green run: exit 0, output identical to staging's, 0.96× baseline runtime, three runs each tree.
- The park class: staged live-handle + stubbed-timer park hangs at staging (killed at 150s bound, still alive); exits 1 at 120s with diagnostics on this branch. The watchdog block extracted verbatim into a minimal probe exits 0 in 84ms when the run is healthy — and the negative control (unref removed) kills healthy runs, proving `unref()` load-bearing.
- The spawnSync bound: a synthetic never-exiting child is killed at 60s and the case goes red; at staging the same probe blocks past 120s.
- No red-rendering changes; diff is 33 insertions / 1 deletion, one file, nothing under `src/`.
- Nothing to verify in-app — this file never ships in the package artifact.

## Documentation impact

- [x] No documentation changes needed — the watchdog carries its rationale as comments where the next harness author will meet it
- [ ] Updated this README catalog and package guidance
- [ ] Updated linked Marinara Engine documentation

## UI evidence (if applicable)

- Not applicable — no UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added safeguards to detect and report stalled test harness runs.
  * Added a timeout for compilation processes to prevent indefinite hangs.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->