### PR TITLE
[codex] scan Agent catalog promotions with CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, staging]
   pull_request:
-    branches: [staging]
+    branches: [main, staging]
   schedule:
     - cron: "17 4 * * 2"
   workflow_dispatch:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,3 +17,5 @@ Catalog SHA-256 values detect accidental corruption and mismatched downloads. Th
 - pins third-party GitHub Actions by full commit SHA.
 
 Repository administrators should keep `staging` protected with pull requests, catalog validation, CodeQL, CodeRabbit, review-thread resolution, and the required owner-approval status check. That check must exempt only active Pasta-Devs organization members and owners; every outside contributor needs a current-head approval from `SpicyMarinara`, and membership or API failures must fail closed. Do not add a repository-role or team bypass that could admit outside collaborators or exclude private organization members. Keep force pushes and branch deletion disabled. Protect `main` separately so only `SpicyMarinara` may promote tested work from `staging`.
+
+CodeQL analyzes pull requests targeting both `staging` and `main`, so the tested catalog retains the same source and workflow scan when it is promoted to the stable channel.

--- a/scripts/validate-pr-triage.mjs
+++ b/scripts/validate-pr-triage.mjs
@@ -40,6 +40,7 @@ export function validatePullRequestTriage() {
   );
   const approvalEvaluator = readFileSync(new URL("./evaluate-owner-approval.mjs", import.meta.url), "utf8");
   const codeOwners = readFileSync(new URL("../.github/CODEOWNERS", import.meta.url), "utf8");
+  const codeqlWorkflow = readFileSync(new URL("../.github/workflows/codeql.yml", import.meta.url), "utf8");
   const triggersSectionStart = triageWorkflow.indexOf("\non:\n");
   const triggersSectionEnd = triageWorkflow.indexOf("\nconcurrency:\n", triggersSectionStart);
   const jobsSectionStart = triageWorkflow.indexOf("\njobs:\n");
@@ -108,6 +109,7 @@ export function validatePullRequestTriage() {
   );
 
   assert.match(codeOwners, /^\* @SpicyMarinara$/mu);
+  assert.match(codeqlWorkflow, /pull_request:\s*\n\s*branches:\s*\[main, staging\]/u);
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {


### PR DESCRIPTION
Closes #573

## Why this change
The downloadable Agent catalog already had clean dependency and code-scanning results, but a direct staging-to-main promotion pull request was outside the CodeQL pull-request trigger.

## What changed
- run CodeQL for pull requests targeting staging or main
- make the repository gate regression enforce both protected targets
- document the promotion scan boundary

No package payload, permission, executable runtime, artifact, checksum, catalog, or user-facing behavior changes.

## Validation
- [ ] Review CodeQL branch coverage
- [ ] Confirm catalog, locale, lint, security, and dependency checks
- [ ] Confirm required GitHub checks and CodeRabbit complete
- [ ] Confirm the staging merge before promotion