### PR TITLE
Skip duplicate CodeRabbit review on main promotions

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -29,6 +29,5 @@ reviews:
     auto_pause_after_reviewed_commits: 0
     base_branches:
       - "staging"
-      - "main"
 chat:
   auto_reply: true


### PR DESCRIPTION
## Linked issue

Closes #610.

## Why this change

Every change entering protected `staging` already requires CodeRabbit review. Running CodeRabbit again on the aggregate owner-only `staging` → `main` promotion re-reviews the same commits, consumes review capacity, and can hold stable publication behind a very large redundant scan.

The existing branch-policy gate independently restricts `main` pull requests to `SpicyMarinara`, the same repository, and the exact `staging` head.

## What changed

- Remove `main` from CodeRabbit automatic-review base branches.
- Keep automatic CodeRabbit review enabled for ready pull requests into `staging`.
- Pair this repository setting with removal of only the `CodeRabbit` required status from the live Main quality gates ruleset; the Staging quality gates ruleset remains unchanged.

## Package and security impact

- Affected package IDs: none.
- Engine compatibility impact: none.
- New or changed permissions/entrypoints: none.
- Restart, storage, update, or uninstall impact: none.
- Governance impact: main promotions reuse the CodeRabbit proof accumulated before each commit entered staging; catalog validation, CodeQL, branch provenance, native Code Quality, PR-template validation, and thread resolution remain enforced on main.

## Validation

- [ ] `npm run check` passes locally
- [ ] `node scripts/test-catalog-lanes.mjs` passes locally
- [ ] `node scripts/validate-package-locales.mjs` passes locally
- [ ] `node scripts/validate-catalog.mjs` passes locally
- [ ] `git diff --check` passes locally
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

Automated validation completed on commit `6181d4bc`:

- Parsed `.coderabbit.yaml` and asserted `reviews.auto_review.base_branches` is exactly `["staging"]`.
- `npx prettier --check .coderabbit.yaml` passed.
- `npm run check` passed with zero errors and 68 warnings.
- Catalog lane, package locale, and full catalog validation passed.
- `git diff --check` passed.
- Confirmed the live Staging quality gates ruleset still requires `CodeRabbit`.
- Confirmed the live main branch-policy check accepts only an owner-authored, same-repository PR whose head is `staging`.

## Documentation impact

- [ ] No documentation changes needed
- [ ] Updated this README catalog and package guidance
- [ ] Updated linked Marinara Engine documentation

No documentation change is needed: `AGENTS.md` and `SECURITY.md` already scope the required CodeRabbit gate to staging and protect main separately as an owner-only promotion target.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated review configuration to target the staging branch only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->