### PR TITLE
feat: publish package release notes beside the catalog

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -66,6 +66,9 @@ jobs:
       - name: Test catalog generatedAt determinism
         run: node scripts/tests/catalog-generatedat-determinism.regression.mjs
 
+      - name: Test package release notes
+        run: node scripts/tests/catalog-release-notes.regression.mjs
+
       - name: Test World Maps UI contracts
         run: node tests/world-maps-ui-contract.regression.mjs
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,8 @@ This file is a thin maintainer note for contributors using coding agents. Canoni
 - Start from `staging` and open an issue before implementation.
 - Open a draft PR when issue work begins so ownership is visible, then mark it ready only after validation and self-review are complete.
 - Run `npm run check` for the maintained-source Prettier and ESLint gates.
-- Run `node scripts/test-catalog-lanes.mjs`, `node scripts/validate-package-locales.mjs`, and `node scripts/validate-catalog.mjs` as the baseline validation commands.
+- Run `node scripts/test-catalog-lanes.mjs`, `node scripts/validate-package-locales.mjs`, `node scripts/validate-catalog.mjs`, and `node scripts/tests/catalog-release-notes.regression.mjs` as the baseline validation commands.
+- A minor or major package version bump needs a `packages/<id>/CHANGELOG.md` entry for the new version; the build rejects one without it. See `CONTRIBUTING.md` § Release notes.
 - Rebuild the affected package and catalog entry whenever source payloads, manifests, Engine snapshots, or generated bundles change.
 - Treat each manifest's `engine.min` / `engine.maxExclusive` range as the catalog-lane source of truth. The builders route packages into `catalog/v*/catalog.json`; do not hand-place or copy entries between lanes.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,34 @@ Both builders accept package IDs for a focused rebuild. When a build changes an 
 
 The catalog `generatedAt` field is preserved across rebuilds rather than stamped with the current time. This keeps a no-op rebuild byte-identical and stops the timestamp from being a guaranteed merge conflict between concurrent package PRs. A rebuild that touches nothing substantive should leave `catalog/**/catalog.json` unchanged — if `git status` shows only a `generatedAt` diff, discard it. To intentionally refresh the timestamp (for example when promoting a release), run the builder with `MARINARA_CATALOG_STAMP_GENERATED_AT=1`.
 
+### Release notes
+
+A package documents its own releases in `packages/<id>/CHANGELOG.md`, newest first:
+
+```markdown
+## 1.3.0 — 2026-09-01
+- Scene detection now handles flashbacks.
+- Fixed the tracker losing state after a summary.
+
+## 1.2.1 — 2026-08-20 [highlight]
+- Fixed the agent silently failing on long chats.
+```
+
+The catalog build turns these into a `notes.json` published beside every `catalog.json` — the published lanes, the legacy alias, and the preview overlay. The Engine shows the newest entry in its update prompt and the whole list as a Version history in Download Agents.
+
+Notes live in a sidecar, never on a catalog entry and never in a manifest. The Engine's catalog entry schema is strict and its parser drops entries carrying keys it does not know, so a new entry key would empty the Agents browser on every already-shipped Engine that predates it. A manifest key is worse: it rewrites every artifact and every checksum to publish a sentence.
+
+Rules:
+
+- **A minor or major bump needs an entry; a patch does not.** The build fails on a feature release with no matching changelog entry, including a package's first appearance. Optional notes rot, and a version history full of gaps reads as abandoned software.
+- **The newest entry must be the version the catalog publishes.** Otherwise the notes describe a release nobody is installing.
+- **The dot means "you will notice this", not "you should install this".** The Engine's prompt updates everything at once; the marker only decides what a user reads first. It defaults from the version bump — minor and major are notable, patch is not — so you rarely set it by hand. `[highlight]` is for a patch that repairs something badly broken; `[quiet]` is for a minor that only adds something invisible. Mark everything and the marker stops meaning anything.
+- **English only.** Notes are not localized. The chrome around them is.
+- **Plain text.** The Engine renders notes verbatim, never as Markdown or HTML, because an operator can point it at any catalog. Bullet characters survive; links and formatting do not.
+- Caps: 1000 characters per entry and 20 entries per package, both enforced at build time. Older entries fall off the end; an over-long entry fails the build rather than being truncated in someone's update prompt.
+
+`validate-catalog.mjs` re-derives every sidecar from the committed changelogs and rejects a mismatch, so a hand-edited `notes.json` cannot drift from the repository.
+
 ### Packages that are not ready for everyone
 
 `scripts/catalog-incomplete.mjs` holds two sets, because "not finished" and "not promoted" are different states. Both keep the package building normally — payload, manifest, artifact, and locales stay committed so development and testing continue — and both are enforced at the single catalog chokepoint (`writeCatalogFamily`), so every builder inherits them and whichever builder runs next relocates or drops a stale committed entry for a newly-marked id.
@@ -123,6 +151,7 @@ npm run check
 node scripts/test-catalog-lanes.mjs
 node scripts/validate-package-locales.mjs
 node scripts/validate-catalog.mjs
+node scripts/tests/catalog-release-notes.regression.mjs
 git diff --check
 ```
 

--- a/scripts/catalog-lanes.mjs
+++ b/scripts/catalog-lanes.mjs
@@ -1,6 +1,7 @@
 import { mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
 import { INCOMPLETE_PACKAGE_IDS, STAGING_ONLY_PACKAGE_IDS } from "./catalog-incomplete.mjs";
+import { assertReleaseNotesForFeatureBumps, buildReleaseNotesDocument } from "./catalog-release-notes.mjs";
 
 export const LEGACY_CATALOG_MAJOR = 2;
 
@@ -256,6 +257,33 @@ async function writePreviewOverlay(repoRoot, previewCatalog) {
   return lanes;
 }
 
+/** Write (or remove) the notes sidecar beside one catalog.json.
+ *
+ *  Removed rather than written empty: the Engine treats an absent document and an
+ *  empty one identically, and an empty file in the tree only invites someone to
+ *  wonder which lane it belongs to. */
+async function writeNotesSidecar(directory, notes) {
+  const path = join(directory, "notes.json");
+  if (Object.keys(notes.packages).length === 0) {
+    await rm(path, { force: true });
+    return;
+  }
+  await mkdir(directory, { recursive: true });
+  await writeFile(path, `${JSON.stringify(notes, null, 2)}\n`);
+}
+
+/** Notes for exactly the packages in one lane, so a sidecar never describes a
+ *  package the Engine reading it cannot see. */
+async function writeLaneNotes(repoRoot, directory, lanes) {
+  for (const [major, lane] of lanes) {
+    await writeNotesSidecar(join(directory, `v${major}`), await buildReleaseNotesDocument(repoRoot, lane.packages));
+  }
+  const legacyLane = lanes.get(LEGACY_CATALOG_MAJOR);
+  if (legacyLane) {
+    await writeNotesSidecar(directory, await buildReleaseNotesDocument(repoRoot, legacyLane.packages));
+  }
+}
+
 export async function writeCatalogFamily(repoRoot, catalog) {
   const catalogDirectory = join(repoRoot, "catalog");
   catalog.generatedAt = await resolveCatalogGeneratedAt(catalogDirectory);
@@ -290,8 +318,21 @@ export async function writeCatalogFamily(repoRoot, catalog) {
   }
   const published = { ...catalog, packages: publishedPackages };
   const catalogsByMajor = createCatalogLanes(published);
+
+  // A minor or major bump owes the user a sentence; a patch may stay silent.
+  // The committed catalog is still on disk at this point, so "what version did
+  // we publish last time" needs no git access and no retroactive changelog for
+  // the packages already out there.
+  const committed = await readCatalogFamily(repoRoot);
+  const previousVersions = new Map(
+    committed.catalog.packages.map((entry) => [entry.manifest.id, entry.manifest.version]),
+  );
+  const allNotes = await buildReleaseNotesDocument(repoRoot, catalog.packages);
+  assertReleaseNotesForFeatureBumps(catalog.packages, allNotes, previousVersions);
+
   await mkdir(catalogDirectory, { recursive: true });
-  await writePreviewOverlay(repoRoot, { ...catalog, packages: previewPackages });
+  const previewLanes = await writePreviewOverlay(repoRoot, { ...catalog, packages: previewPackages });
+  await writeLaneNotes(repoRoot, previewCatalogDirectory(repoRoot), previewLanes);
 
   const entries = await readdir(catalogDirectory, { withFileTypes: true });
   const expectedDirectories = new Set([...catalogsByMajor.keys()].map((major) => `v${major}`));
@@ -313,5 +354,6 @@ export async function writeCatalogFamily(repoRoot, catalog) {
   const legacyCatalog = catalogsByMajor.get(LEGACY_CATALOG_MAJOR);
   if (!legacyCatalog) throw new Error(`Missing legacy v${LEGACY_CATALOG_MAJOR} catalog lane`);
   await writeFile(join(catalogDirectory, "catalog.json"), `${JSON.stringify(legacyCatalog, null, 2)}\n`);
+  await writeLaneNotes(repoRoot, catalogDirectory, catalogsByMajor);
   return catalogsByMajor;
 }

--- a/scripts/catalog-release-notes.mjs
+++ b/scripts/catalog-release-notes.mjs
@@ -1,0 +1,167 @@
+import { readFile, readdir } from "node:fs/promises";
+import { join } from "node:path";
+
+// Release notes are published as notes.json BESIDE the catalog.json they
+// describe — never as a key on a catalog entry and never inside a package
+// manifest.
+//
+// The Engine's catalog entry schema is strict and its parser DROPS entries
+// carrying keys it does not know, so a new entry key would empty the Agents
+// browser on every already-shipped Engine that predates it, not merely hide the
+// notes. A manifest key is worse still: it rewrites every artifact and every
+// sha256 to publish a sentence. A sibling document old Engines never request has
+// neither problem, and an Engine that does request it treats a 404 as "no notes".
+
+/** Mirrors the Engine's capabilityReleaseNotesSchema. Kept in step by hand; the
+ *  Engine rejects the whole document if either cap is exceeded, so a drift here
+ *  fails loudly at fetch time rather than truncating a note into a modal. */
+export const MAX_RELEASE_NOTE_CHARACTERS = 1000;
+export const MAX_RELEASE_NOTE_VERSIONS = 20;
+
+const SEMVER_PATTERN = /^(\d+)\.(\d+)\.(\d+)(?:-[0-9A-Za-z.-]+)?$/u;
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/u;
+// "## 1.3.0 — 2026-09-01 [highlight]" — em dash or hyphen, marker optional.
+const HEADING_PATTERN = /^##\s+(\S+)\s+[—-]\s+(\S+)\s*(\[[a-z]+\])?\s*$/u;
+
+function parseSemver(value, context) {
+  const match = SEMVER_PATTERN.exec(value);
+  if (!match) throw new Error(`${context}: "${value}" is not a valid version`);
+  return match.slice(1, 4).map(Number);
+}
+
+/** Whether moving from `previous` to `version` changed the major or minor part.
+ *
+ *  This is the default for the highlight dot, and it is why authors almost never
+ *  have to think about the flag: semver already encodes "the user will notice
+ *  this". The explicit markers exist for the two cases semver gets wrong — a
+ *  patch that repairs a badly broken agent, and a minor that only adds a setting
+ *  nobody sees. */
+function isNotableBump(version, previous, context) {
+  if (!previous) return false;
+  const [major, minor] = parseSemver(version, context);
+  const [previousMajor, previousMinor] = parseSemver(previous, context);
+  return major !== previousMajor || minor !== previousMinor;
+}
+
+/** Parse one package CHANGELOG.md into catalog notes entries, newest first. */
+export function parsePackageChangelog(markdown, context) {
+  const lines = markdown.split(/\r?\n/u);
+  const sections = [];
+  for (const line of lines) {
+    const heading = HEADING_PATTERN.exec(line.trim());
+    if (heading) {
+      sections.push({ version: heading[1], date: heading[2], marker: heading[3] ?? null, body: [] });
+      continue;
+    }
+    // Anything before the first heading is a title or preamble and is dropped.
+    if (sections.length > 0) sections.at(-1).body.push(line);
+  }
+  if (sections.length === 0) throw new Error(`${context}: no "## <version> — <YYYY-MM-DD>" entries found`);
+
+  const seen = new Set();
+  const entries = sections.map((section, index) => {
+    parseSemver(section.version, context);
+    if (!DATE_PATTERN.test(section.date)) {
+      throw new Error(`${context}: ${section.version} needs a YYYY-MM-DD date, got "${section.date}"`);
+    }
+    if (seen.has(section.version)) throw new Error(`${context}: ${section.version} is listed twice`);
+    seen.add(section.version);
+
+    const notes = section.body.join("\n").trim();
+    if (!notes) throw new Error(`${context}: ${section.version} has no notes`);
+    if (notes.length > MAX_RELEASE_NOTE_CHARACTERS) {
+      throw new Error(
+        `${context}: ${section.version} has ${notes.length} characters of notes, over the ${MAX_RELEASE_NOTE_CHARACTERS} cap`,
+      );
+    }
+    if (section.marker && section.marker !== "[highlight]" && section.marker !== "[quiet]") {
+      throw new Error(`${context}: ${section.version} has an unknown marker ${section.marker}`);
+    }
+
+    const previous = sections[index + 1]?.version ?? null;
+    const highlight =
+      section.marker === "[highlight]"
+        ? true
+        : section.marker === "[quiet]"
+          ? false
+          : isNotableBump(section.version, previous, context);
+    return { version: section.version, date: section.date, notes, highlight };
+  });
+
+  for (let index = 1; index < entries.length; index += 1) {
+    const [major, minor, patch] = parseSemver(entries[index - 1].version, context);
+    const [olderMajor, olderMinor, olderPatch] = parseSemver(entries[index].version, context);
+    const newer = major * 1e6 + minor * 1e3 + patch;
+    const older = olderMajor * 1e6 + olderMinor * 1e3 + olderPatch;
+    if (newer <= older) throw new Error(`${context}: entries must be newest first`);
+  }
+
+  // Older entries fall off the end rather than failing the build: a long-lived
+  // package must not become unpublishable because it has shipped 30 versions.
+  return entries.slice(0, MAX_RELEASE_NOTE_VERSIONS);
+}
+
+/** Notes for one package, or null when it publishes no CHANGELOG.md. */
+export async function readPackageReleaseNotes(repoRoot, id) {
+  let markdown;
+  try {
+    markdown = await readFile(join(repoRoot, "packages", id, "CHANGELOG.md"), "utf8");
+  } catch {
+    return null;
+  }
+  return parsePackageChangelog(markdown, `packages/${id}/CHANGELOG.md`);
+}
+
+/** Build the notes document for a set of catalog entries.
+ *
+ *  Throws when a package's committed CHANGELOG.md does not lead with the version
+ *  the catalog is about to publish, so notes cannot silently describe the wrong
+ *  release. */
+export async function buildReleaseNotesDocument(repoRoot, entries) {
+  const packages = {};
+  for (const entry of [...entries].sort((left, right) => left.manifest.id.localeCompare(right.manifest.id))) {
+    const { id, version } = entry.manifest;
+    const versions = await readPackageReleaseNotes(repoRoot, id);
+    if (!versions) continue;
+    if (versions[0].version !== version) {
+      throw new Error(
+        `packages/${id}/CHANGELOG.md leads with ${versions[0].version} but the catalog publishes ${version}`,
+      );
+    }
+    packages[id] = { versions };
+  }
+  return { schemaVersion: 1, packages };
+}
+
+/** Every package id that ships a CHANGELOG.md, for coverage reporting. */
+export async function listPackagesWithChangelogs(repoRoot) {
+  const ids = [];
+  const directories = await readdir(join(repoRoot, "packages"), { withFileTypes: true });
+  for (const directory of directories) {
+    if (!directory.isDirectory()) continue;
+    if ((await readPackageReleaseNotes(repoRoot, directory.name)) !== null) ids.push(directory.name);
+  }
+  return ids.sort();
+}
+
+/** Fail a build that ships a feature release with no notes.
+ *
+ *  Optional notes rot: authors skip them, and within two months the version
+ *  history looks abandoned. Patch releases may stay silent, but a minor or major
+ *  bump — including a package's first appearance — owes the user a sentence.
+ *  `previousVersions` comes from the catalog committed before this build, so the
+ *  gate needs no retroactive changelog for the packages already published. */
+export function assertReleaseNotesForFeatureBumps(entries, notesDocument, previousVersions) {
+  for (const entry of entries) {
+    const { id, version } = entry.manifest;
+    const previous = previousVersions.get(id) ?? null;
+    if (previous === version) continue;
+    if (!isNotableBump(version, previous ?? "0.0.0", `packages/${id}`)) continue;
+    const published = notesDocument.packages[id]?.versions.some((note) => note.version === version);
+    if (published) continue;
+    throw new Error(
+      `${id} ${version} is a feature release${previous ? ` (was ${previous})` : ""} with no packages/${id}/CHANGELOG.md entry. ` +
+        `Add one, or ship it as a patch release.`,
+    );
+  }
+}

--- a/scripts/catalog-release-notes.mjs
+++ b/scripts/catalog-release-notes.mjs
@@ -29,6 +29,46 @@ function parseSemver(value, context) {
   return match.slice(1, 4).map(Number);
 }
 
+/** SemVer precedence, so ordering does not depend on any component staying small.
+ *
+ *  Packed arithmetic (major * 1e6 + minor * 1e3 + patch) looks tidy and is wrong:
+ *  1.0.1001 outranks 1.1.0 under it. A release carrying a prerelease suffix also
+ *  precedes the release it leads to, per SemVer, and dotted prerelease identifiers
+ *  compare numerically when both sides are numeric and as text otherwise. */
+function comparePrereleaseIdentifiers(left, right) {
+  const leftParts = left.split(".");
+  const rightParts = right.split(".");
+  for (let index = 0; index < Math.max(leftParts.length, rightParts.length); index += 1) {
+    const leftPart = leftParts[index];
+    const rightPart = rightParts[index];
+    // A shorter set of identifiers has lower precedence when all preceding ones are equal.
+    if (leftPart === undefined) return -1;
+    if (rightPart === undefined) return 1;
+    if (leftPart === rightPart) continue;
+    const leftNumeric = /^\d+$/u.test(leftPart);
+    const rightNumeric = /^\d+$/u.test(rightPart);
+    if (leftNumeric && rightNumeric) return Number(leftPart) - Number(rightPart);
+    // Numeric identifiers always have lower precedence than alphanumeric ones.
+    if (leftNumeric !== rightNumeric) return leftNumeric ? -1 : 1;
+    return leftPart < rightPart ? -1 : 1;
+  }
+  return 0;
+}
+
+export function compareVersions(left, right, context) {
+  const leftParts = parseSemver(left, context);
+  const rightParts = parseSemver(right, context);
+  for (let index = 0; index < 3; index += 1) {
+    if (leftParts[index] !== rightParts[index]) return leftParts[index] - rightParts[index];
+  }
+  const leftPrerelease = left.includes("-") ? left.slice(left.indexOf("-") + 1) : null;
+  const rightPrerelease = right.includes("-") ? right.slice(right.indexOf("-") + 1) : null;
+  if (leftPrerelease === rightPrerelease) return 0;
+  if (leftPrerelease === null) return 1;
+  if (rightPrerelease === null) return -1;
+  return comparePrereleaseIdentifiers(leftPrerelease, rightPrerelease);
+}
+
 /** Whether moving from `previous` to `version` changed the major or minor part.
  *
  *  This is the default for the highlight dot, and it is why authors almost never
@@ -89,11 +129,9 @@ export function parsePackageChangelog(markdown, context) {
   });
 
   for (let index = 1; index < entries.length; index += 1) {
-    const [major, minor, patch] = parseSemver(entries[index - 1].version, context);
-    const [olderMajor, olderMinor, olderPatch] = parseSemver(entries[index].version, context);
-    const newer = major * 1e6 + minor * 1e3 + patch;
-    const older = olderMajor * 1e6 + olderMinor * 1e3 + olderPatch;
-    if (newer <= older) throw new Error(`${context}: entries must be newest first`);
+    if (compareVersions(entries[index - 1].version, entries[index].version, context) <= 0) {
+      throw new Error(`${context}: entries must be newest first`);
+    }
   }
 
   // Older entries fall off the end rather than failing the build: a long-lived
@@ -106,8 +144,12 @@ export async function readPackageReleaseNotes(repoRoot, id) {
   let markdown;
   try {
     markdown = await readFile(join(repoRoot, "packages", id, "CHANGELOG.md"), "utf8");
-  } catch {
-    return null;
+  } catch (error) {
+    // Only a missing file means "this package publishes no notes". A permission
+    // error or an unreadable directory swallowed here would silently drop a
+    // package's notes from the catalog instead of failing the build.
+    if (error?.code === "ENOENT") return null;
+    throw error;
   }
   return parsePackageChangelog(markdown, `packages/${id}/CHANGELOG.md`);
 }
@@ -156,7 +198,9 @@ export function assertReleaseNotesForFeatureBumps(entries, notesDocument, previo
     const { id, version } = entry.manifest;
     const previous = previousVersions.get(id) ?? null;
     if (previous === version) continue;
-    if (!isNotableBump(version, previous ?? "0.0.0", `packages/${id}`)) continue;
+    // A first appearance always owes notes, checked before the bump test: an
+    // initial 0.0.1 reads as a patch against a synthetic 0.0.0 and would slip past.
+    if (previous !== null && !isNotableBump(version, previous, `packages/${id}`)) continue;
     const published = notesDocument.packages[id]?.versions.some((note) => note.version === version);
     if (published) continue;
     throw new Error(

--- a/scripts/tests/catalog-release-notes.regression.mjs
+++ b/scripts/tests/catalog-release-notes.regression.mjs
@@ -1,0 +1,164 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { writeCatalogFamily } from "../catalog-lanes.mjs";
+import {
+  MAX_RELEASE_NOTE_CHARACTERS,
+  MAX_RELEASE_NOTE_VERSIONS,
+  assertReleaseNotesForFeatureBumps,
+  buildReleaseNotesDocument,
+  parsePackageChangelog,
+} from "../catalog-release-notes.mjs";
+
+// Release notes ship as notes.json beside the catalog.json they describe, built
+// from each package's CHANGELOG.md. These checks pin the parts a mistake would
+// otherwise surface only in a user's update prompt:
+//   * the highlight dot defaults from the semver bump, so authors do not have to
+//     remember it, with explicit markers for the cases semver gets wrong;
+//   * the caps the Engine schema also enforces fail the BUILD instead of being
+//     truncated into a modal at fetch time;
+//   * a sidecar only ever describes packages in its own lane, and disappears
+//     when a lane has no notes at all;
+//   * a minor or major bump with no changelog entry fails the build, because
+//     optional notes rot and a version history full of gaps reads as abandoned.
+
+function entry(id, version, { min = "2.3.0", maxExclusive = "3.0.0" } = {}) {
+  return {
+    manifest: {
+      schemaVersion: 1,
+      id,
+      name: id,
+      version,
+      engine: { min, maxExclusive },
+    },
+  };
+}
+
+// ── Parsing and the highlight default ─────────────────────────────────────────
+const parsed = parsePackageChangelog(
+  [
+    "# Background",
+    "",
+    "## 1.2.0 — 2026-09-01",
+    "- Handles flashbacks.",
+    "",
+    "## 1.1.1 — 2026-08-20 [highlight]",
+    "- Fixed a silent failure on long chats.",
+    "",
+    "## 1.1.0 — 2026-08-10 [quiet]",
+    "- Added an internal setting nobody sees.",
+    "",
+    "## 1.0.0 — 2026-08-01",
+    "- First release.",
+  ].join("\n"),
+  "fixture",
+);
+assert.deepEqual(
+  parsed.map((note) => [note.version, note.highlight]),
+  [
+    ["1.2.0", true], // minor bump: notable by default
+    ["1.1.1", true], // patch, but the author overrode it
+    ["1.1.0", false], // minor, but the author quieted it
+    ["1.0.0", false], // nothing older to compare against
+  ],
+  "highlight derives from the semver bump unless the author overrides it",
+);
+assert.equal(parsed[0].notes, "- Handles flashbacks.", "Prose before the first heading is not part of any entry");
+
+// ── Authoring mistakes fail loudly ────────────────────────────────────────────
+const rejects = [
+  ["## 1.0.0 — 2026-09-01\n", /has no notes/u],
+  ["## 1.0 — 2026-09-01\n- x\n", /not a valid version/u],
+  ["## 1.0.0 — 09-01-2026\n- x\n", /YYYY-MM-DD/u],
+  ["## 1.0.0 — 2026-09-01 [urgent]\n- x\n", /unknown marker/u],
+  ["## 1.0.0 — 2026-09-01\n- x\n\n## 1.0.0 — 2026-08-01\n- y\n", /listed twice/u],
+  ["## 1.0.0 — 2026-08-01\n- x\n\n## 1.1.0 — 2026-09-01\n- y\n", /newest first/u],
+  ["Nothing here at all.\n", /no "## <version>/u],
+  [`## 1.0.0 — 2026-09-01\n${"x".repeat(MAX_RELEASE_NOTE_CHARACTERS + 1)}\n`, /over the 1000 cap/u],
+];
+for (const [markdown, pattern] of rejects) {
+  assert.throws(() => parsePackageChangelog(markdown, "fixture"), pattern);
+}
+
+// A long-lived package must stay publishable, so old entries fall off the end
+// rather than failing the build.
+const long = Array.from({ length: MAX_RELEASE_NOTE_VERSIONS + 5 }, (_, index) => {
+  const version = MAX_RELEASE_NOTE_VERSIONS + 5 - index;
+  return `## 1.0.${version} — 2026-09-01\n- Change ${version}.\n`;
+}).join("\n");
+assert.equal(parsePackageChangelog(long, "fixture").length, MAX_RELEASE_NOTE_VERSIONS);
+
+// ── The feature-release gate ──────────────────────────────────────────────────
+const emptyNotes = { schemaVersion: 1, packages: {} };
+assert.doesNotThrow(
+  () => assertReleaseNotesForFeatureBumps([entry("alpha", "1.0.1")], emptyNotes, new Map([["alpha", "1.0.0"]])),
+  "A patch release may ship silently",
+);
+assert.doesNotThrow(
+  () => assertReleaseNotesForFeatureBumps([entry("alpha", "1.0.0")], emptyNotes, new Map([["alpha", "1.0.0"]])),
+  "An unchanged package is not a release at all",
+);
+assert.throws(
+  () => assertReleaseNotesForFeatureBumps([entry("alpha", "1.1.0")], emptyNotes, new Map([["alpha", "1.0.0"]])),
+  /feature release \(was 1\.0\.0\) with no packages\/alpha\/CHANGELOG\.md entry/u,
+);
+assert.throws(
+  () => assertReleaseNotesForFeatureBumps([entry("alpha", "1.0.0")], emptyNotes, new Map()),
+  /with no packages\/alpha\/CHANGELOG\.md entry/u,
+  "A package's first appearance owes the user a sentence too",
+);
+
+// ── End to end through the lane chokepoint ────────────────────────────────────
+const root = await mkdtemp(join(tmpdir(), "agents-release-notes-"));
+try {
+  await mkdir(join(root, "packages/alpha"), { recursive: true });
+  await mkdir(join(root, "packages/beta"), { recursive: true });
+  await writeFile(join(root, "packages/alpha/CHANGELOG.md"), "## 1.1.0 — 2026-09-01\n- Alpha grew a feature.\n");
+  await writeFile(join(root, "packages/beta/CHANGELOG.md"), "## 1.0.0 — 2026-09-01\n- Beta arrived.\n");
+
+  // beta spans v2 and v3; alpha is v2 only. A sidecar must never describe a
+  // package the Engine reading that lane cannot install.
+  const catalog = {
+    schemaVersion: 1,
+    generatedAt: "2026-01-01T00:00:00.000Z",
+    packages: [entry("alpha", "1.1.0"), entry("beta", "1.0.0", { maxExclusive: "4.0.0" })],
+  };
+  await writeCatalogFamily(root, catalog);
+
+  const legacy = JSON.parse(await readFile(join(root, "catalog/notes.json"), "utf8"));
+  assert.deepEqual(Object.keys(legacy.packages), ["alpha", "beta"]);
+  assert.equal(legacy.packages.alpha.versions[0].notes, "- Alpha grew a feature.");
+  assert.deepEqual(
+    JSON.parse(await readFile(join(root, "catalog/v2/notes.json"), "utf8")),
+    legacy,
+    "The legacy alias mirrors the v2 lane, notes included",
+  );
+  assert.deepEqual(
+    Object.keys(JSON.parse(await readFile(join(root, "catalog/v3/notes.json"), "utf8")).packages),
+    ["beta"],
+    "The v3 sidecar carries only the packages published in the v3 lane",
+  );
+
+  // A changelog that does not lead with the version being published would
+  // describe the wrong release to every user reading the prompt.
+  await writeFile(join(root, "packages/alpha/CHANGELOG.md"), "## 9.9.9 — 2026-09-01\n- Wrong release.\n");
+  await assert.rejects(
+    buildReleaseNotesDocument(root, catalog.packages),
+    /leads with 9\.9\.9 but the catalog publishes 1\.1\.0/u,
+  );
+
+  // Withdrawing every changelog removes the sidecars rather than leaving empty
+  // documents behind. Versions are unchanged, so the feature-release gate has
+  // nothing to complain about.
+  await rm(join(root, "packages/alpha/CHANGELOG.md"));
+  await rm(join(root, "packages/beta/CHANGELOG.md"));
+  await writeCatalogFamily(root, catalog);
+  for (const path of ["catalog/notes.json", "catalog/v2/notes.json", "catalog/v3/notes.json"]) {
+    await assert.rejects(readFile(join(root, path), "utf8"), /ENOENT/u, `${path} must not survive as an empty file`);
+  }
+} finally {
+  await rm(root, { recursive: true, force: true });
+}
+
+console.log("catalog release notes: OK");

--- a/scripts/tests/catalog-release-notes.regression.mjs
+++ b/scripts/tests/catalog-release-notes.regression.mjs
@@ -8,6 +8,7 @@ import {
   MAX_RELEASE_NOTE_VERSIONS,
   assertReleaseNotesForFeatureBumps,
   buildReleaseNotesDocument,
+  compareVersions,
   parsePackageChangelog,
 } from "../catalog-release-notes.mjs";
 
@@ -34,6 +35,23 @@ function entry(id, version, { min = "2.3.0", maxExclusive = "3.0.0" } = {}) {
     },
   };
 }
+
+// ── SemVer precedence ─────────────────────────────────────────────────────────
+// Packed arithmetic (major * 1e6 + minor * 1e3 + patch) reads tidily and ranks
+// 1.0.1001 above 1.1.0, which would let an out-of-order changelog through.
+assert.ok(compareVersions("1.1.0", "1.0.1001", "fixture") > 0, "A minor bump outranks any patch count");
+assert.ok(compareVersions("2.0.0", "1.999.999", "fixture") > 0);
+assert.ok(compareVersions("1.0.0", "1.0.0-rc.1", "fixture") > 0, "A release outranks its own prerelease");
+assert.ok(compareVersions("1.0.0-rc.2", "1.0.0-rc.1", "fixture") > 0, "Numeric identifiers compare numerically");
+assert.ok(compareVersions("1.0.0-rc.10", "1.0.0-rc.9", "fixture") > 0, "…not as text");
+assert.ok(compareVersions("1.0.0-beta", "1.0.0-alpha", "fixture") > 0);
+assert.ok(compareVersions("1.0.0-rc.1.1", "1.0.0-rc.1", "fixture") > 0, "More identifiers outrank fewer");
+assert.equal(compareVersions("1.2.3", "1.2.3", "fixture"), 0);
+
+assert.doesNotThrow(
+  () => parsePackageChangelog("## 1.1.0 — 2026-09-01\n- x\n\n## 1.0.1001 — 2026-08-01\n- y\n", "fixture"),
+  "A high patch count below a minor bump is correctly ordered",
+);
 
 // ── Parsing and the highlight default ─────────────────────────────────────────
 const parsed = parsePackageChangelog(
@@ -107,6 +125,11 @@ assert.throws(
   () => assertReleaseNotesForFeatureBumps([entry("alpha", "1.0.0")], emptyNotes, new Map()),
   /with no packages\/alpha\/CHANGELOG\.md entry/u,
   "A package's first appearance owes the user a sentence too",
+);
+assert.throws(
+  () => assertReleaseNotesForFeatureBumps([entry("alpha", "0.0.1")], emptyNotes, new Map()),
+  /with no packages\/alpha\/CHANGELOG\.md entry/u,
+  "…including one that first appears at 0.0.1, which reads as a patch against a synthetic 0.0.0",
 );
 
 // ── End to end through the lane chokepoint ────────────────────────────────────

--- a/scripts/validate-catalog.mjs
+++ b/scripts/validate-catalog.mjs
@@ -126,10 +126,20 @@ if (JSON.stringify(legacyCatalog) !== JSON.stringify(catalogsByMajor.get(LEGACY_
 // notes.json was hand-edited, or a changelog changed without a rebuild, and the
 // text users read in the update prompt would no longer match the repository.
 async function readCommittedNotes(path) {
+  let raw;
   try {
-    return JSON.parse(await readFile(join(repoRoot, path), "utf8"));
-  } catch {
-    return null;
+    raw = await readFile(join(repoRoot, path), "utf8");
+  } catch (error) {
+    // Only a missing file counts as "no sidecar". Mapping a parse failure or a
+    // permission error to absent would let a corrupt notes.json pass validation
+    // for any lane that is expected to have none.
+    if (error?.code === "ENOENT") return null;
+    throw error;
+  }
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`${path} is not valid JSON`, { cause: error });
   }
 }
 
@@ -152,6 +162,10 @@ if (previewCatalog.packages.length > 0) {
     await assertNotesSidecar(`catalog/preview/v${major}/notes.json`, lane.packages);
   }
   await assertNotesSidecar("catalog/preview/notes.json", expectedPreviewLanes.get(LEGACY_CATALOG_MAJOR).packages);
+} else if ((await readCommittedNotes("catalog/preview/notes.json")) !== null) {
+  // The overlay directory is removed when nothing is staging-only, so a surviving
+  // sidecar means a stale generated payload that no rebuild would produce.
+  throw new Error("catalog/preview/notes.json exists with no staging-only packages — rebuild the catalog to remove it");
 }
 const packagesWithChangelogs = await listPackagesWithChangelogs(repoRoot);
 console.log(

--- a/scripts/validate-catalog.mjs
+++ b/scripts/validate-catalog.mjs
@@ -12,6 +12,7 @@ import {
   createCatalogLanes,
   readCatalogFamily,
 } from "./catalog-lanes.mjs";
+import { buildReleaseNotesDocument, listPackagesWithChangelogs } from "./catalog-release-notes.mjs";
 import { assertHierarchicalMapsPrivateImportBoundary } from "./hierarchical-maps-boundary.mjs";
 import { INCOMPLETE_PACKAGE_IDS, STAGING_ONLY_PACKAGE_IDS } from "./catalog-incomplete.mjs";
 import { assertPackagePrivateImportBoundary } from "./package-engine-boundary.mjs";
@@ -118,6 +119,44 @@ for (const [major, expectedCatalog] of expectedCatalogsByMajor) {
 if (JSON.stringify(legacyCatalog) !== JSON.stringify(catalogsByMajor.get(LEGACY_CATALOG_MAJOR))) {
   throw new Error(`catalog/catalog.json must remain an exact alias of catalog/v${LEGACY_CATALOG_MAJOR}/catalog.json`);
 }
+
+// Release-notes sidecars get the same treatment as the lanes they sit beside: a
+// committed notes.json must be exactly what a rebuild produces, and a lane whose
+// packages publish no notes must carry no sidecar at all. Anything else means a
+// notes.json was hand-edited, or a changelog changed without a rebuild, and the
+// text users read in the update prompt would no longer match the repository.
+async function readCommittedNotes(path) {
+  try {
+    return JSON.parse(await readFile(join(repoRoot, path), "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+async function assertNotesSidecar(path, entries) {
+  const expected = await buildReleaseNotesDocument(repoRoot, entries);
+  const committed = await readCommittedNotes(path);
+  const wanted = Object.keys(expected.packages).length > 0 ? expected : null;
+  if (JSON.stringify(committed) !== JSON.stringify(wanted)) {
+    throw new Error(`${path} does not match the committed package changelogs — rebuild the catalog`);
+  }
+}
+
+for (const [major, lane] of expectedCatalogsByMajor) {
+  await assertNotesSidecar(`catalog/v${major}/notes.json`, lane.packages);
+}
+await assertNotesSidecar("catalog/notes.json", expectedCatalogsByMajor.get(LEGACY_CATALOG_MAJOR).packages);
+if (previewCatalog.packages.length > 0) {
+  const expectedPreviewLanes = createCatalogLanes(previewCatalog);
+  for (const [major, lane] of expectedPreviewLanes) {
+    await assertNotesSidecar(`catalog/preview/v${major}/notes.json`, lane.packages);
+  }
+  await assertNotesSidecar("catalog/preview/notes.json", expectedPreviewLanes.get(LEGACY_CATALOG_MAJOR).packages);
+}
+const packagesWithChangelogs = await listPackagesWithChangelogs(repoRoot);
+console.log(
+  `Release notes: ${packagesWithChangelogs.length}/${publishedCatalog.packages.length} published packages ship a CHANGELOG.md.`,
+);
 const hierarchicalMapsBoundary = await assertHierarchicalMapsPrivateImportBoundary();
 
 const hierarchicalMapsOwnedSourcePaths = [


### PR DESCRIPTION
## Linked issue

Closes #687

## Why this change

- Packages version and update independently, but this repository stores no release-notes data at all — version history exists only as `artifacts/` filenames and git history, neither of which a user ever sees. The Engine can therefore only show two version numbers, so a user has no basis to accept or decline an update and no way to learn what an installed Agent changed.
- Nothing distinguishes a routine bugfix release from one that changes behaviour, which trains people to dismiss update prompts unread — exactly when a real change slips past.

## What changed

- **New `scripts/catalog-release-notes.mjs`** — parses `packages/<id>/CHANGELOG.md` (`## <version> — <YYYY-MM-DD>` headings, newest first) into catalog notes entries, derives the notable-change marker from the version bump, and enforces the caps the Engine schema also applies.
- **`scripts/catalog-lanes.mjs`** — `writeCatalogFamily`, the single chokepoint every builder already writes through, now emits a `notes.json` beside every `catalog.json`: the published lanes, the legacy alias, and the preview overlay, each scoped to the packages in that lane. All five builders inherit it, including for entries `readCatalogFamily` preserves without rebuilding. A lane whose packages publish no notes gets no sidecar rather than an empty file. The same function fails the build on a minor or major bump with no changelog entry, using the catalog committed before the build as the previous version.
- **`scripts/validate-catalog.mjs`** — re-derives every sidecar from the committed changelogs and rejects a mismatch, so a hand-edited `notes.json` cannot drift. Also reports changelog coverage.
- **`scripts/tests/catalog-release-notes.regression.mjs`** — new, and added to `pull-request-checks.yml`.
- **`CONTRIBUTING.md`, `AGENTS.md`** — the authoring format and the rules.

Affected package IDs: none. No package payload, manifest, artifact, or catalog entry changes.

**Why a sidecar and not a catalog or manifest field.** The Engine's catalog entry schema is strict and its parser *drops* entries carrying keys it does not know, so a new entry key would empty the Agents browser on every already-shipped Engine that predates it — not merely hide the notes. A manifest key is worse: it rewrites every artifact and every checksum to publish a sentence, and trips the source/catalog/archive manifest equality checks.

**Rules the build enforces.** A minor or major bump needs an entry and a patch does not, because optional notes rot and a version history full of gaps reads as abandoned software. The newest entry must be the version being published. Caps are 1000 characters per entry and 20 entries per package; older entries fall off the end, an over-long one fails the build rather than being truncated in someone's update prompt. Notes are English only and plain text — the Engine renders them verbatim, never as Markdown or HTML, because an operator can point it at any catalog.

**No package ships a `CHANGELOG.md` in this PR.** The mechanism lands first; notes get written by whoever knows what a release actually changed, and inventing them here would put fiction in front of users. Coverage currently reports 0/36 and rises as packages ship their next feature release.

Pairs with Pasta-Devs/Marinara-Engine#5772, which renders the notes. Ordering does not matter: an Engine without that PR never requests the sidecar, and an Engine with it treats a missing sidecar as "no notes".

## Package and security impact

- Affected package IDs: none
- Engine compatibility impact: none — no catalog entry, manifest, or artifact bytes change. The new sidecar is a separate document that only an Engine with #5772 requests.
- New or changed permissions/entrypoints: none
- Restart, storage, update, or uninstall impact: none

## Validation

<!-- These are human tasks. Never tick a box for a check that was not actually performed. -->

- [ ] `node scripts/validate-catalog.mjs` passes locally
- [ ] `git diff --check` passes locally
- [ ] Rebuilt every affected manifest, payload, artifact, and catalog entry
- [ ] Installed or updated the affected package through Marinara Engine
- [ ] Checked supported modes, restart behavior, and uninstall cleanup
- [ ] Read and followed `CONTRIBUTING.md`

Also needed, beyond the standard list:

- [ ] `npm run check`
- [ ] `npm run test:security`
- [ ] `node scripts/test-catalog-lanes.mjs`
- [ ] `node scripts/validate-package-locales.mjs`
- [ ] `node scripts/validate-package-locale-keys.mjs`
- [ ] `node scripts/tests/catalog-generatedat-determinism.regression.mjs`
- [ ] `node scripts/tests/catalog-release-notes.regression.mjs`

### Manual verification notes

- [ ] Add a `CHANGELOG.md` to one package, rebuild, and manually verify the expected `notes.json` files appear in the published lanes and the legacy alias.
- [ ] Manually verify a rebuild with no changelog changes leaves the tree clean.
- [ ] Bump a package's minor version without a changelog entry and manually verify the build refuses it.
- [ ] Serve the built catalog to a local Engine running Marinara-Engine#5772 and manually verify the notes reach the update prompt and Download Agents.

## Documentation impact

- [ ] No documentation changes needed
- [x] Updated this README catalog and package guidance — `CONTRIBUTING.md` § Release notes and `AGENTS.md` baseline commands. The README catalog tables are unchanged because no package listing changed.
- [ ] Updated linked Marinara Engine documentation — covered by Pasta-Devs/Marinara-Engine#5772.

## UI evidence (if applicable)

Not applicable — this repository publishes data, and the UI lives in Pasta-Devs/Marinara-Engine#5772.