### PR TITLE
Issue sweep: Illustrator manual-only guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Across its Engine compatibility lanes, the catalog currently contains **36 first
 
 For complete mode, lifecycle, and settings documentation for every package, see the Engine's [Downloadable Agents Reference](https://github.com/Pasta-Devs/Marinara-Engine/blob/staging/docs/agents/built-in-agents.md).
 
+For manual-only Illustrator on the updated Engine staging build, set **Run Interval** to **0** in its setup or when adding it to a chat. This stops automatic Illustrator runs, including automatic scene backgrounds, while keeping the **Gallery → Illustrate** and **Background** actions available. The default remains **5**; choose a positive interval to resume automatic runs. This is an Engine scheduling option, so no Illustrator package update is required.
+
 ### In development
 
 These packages are being built in this repository but are not ready for the stable catalog yet. A package is either **in development** (hidden from every Engine channel) or **staging only** (offered to Engine `staging` testers, hidden from stable `main` users). See [Contributing § Packages that are not ready for everyone](CONTRIBUTING.md#packages-that-are-not-ready-for-everyone).


### PR DESCRIPTION
# Issue sweep: Illustrator manual-only guidance

## Linked issue

Closes #629, paired with the host implementation in Pasta-Devs/Marinara-Engine#5865.

## Why this change

Users want to keep Illustrator installed and generate only when they explicitly ask. The maintainer requested run interval 0 rather than a new setting or disabling/reinstalling the Agent.

## What changed

- Document run interval 0 for manual-only Illustrator on the matching updated Engine staging build.
- Keep the existing interval of 5 for automatic generation by default.
- Scheduling and cadence controls remain Engine-owned in the paired PR; no copied runtime or unnecessary package rebuild.

## Package and security impact

- Affected package IDs: illustrator (documentation only).
- Engine compatibility impact: manual-only scheduling requires the paired updated Engine staging build.
- New or changed permissions/entrypoints: none.
- Restart, storage, update, or uninstall impact: none.

## Validation

- [ ] Run the maintained-source formatting and lint checks.
- [ ] Run catalog lanes, package locales, catalog validation, and release-note regressions.
- [ ] Verify `git diff --check`.
- [ ] Manually verify interval 0 remains selected and prevents automatic runs in a compatible Engine.
- [ ] Manually verify existing manual generation still works.

### Manual verification notes

Local automated validation passed: `npm run check` (existing warnings only), `node scripts/test-catalog-lanes.mjs`, `node scripts/validate-package-locales.mjs`, `node scripts/validate-catalog.mjs`, `node scripts/tests/catalog-release-notes.regression.mjs`, and `git diff --check`. The patch changes only the README; package rebuild and install lifecycle testing are not applicable. No live model generation is claimed. The paired Engine PR carries the settings/scheduling regression proof and must land before this issue is closed.

## Documentation impact

- README Illustrator guidance; linked Engine documentation updated in the paired host PR.

## UI evidence

No package-owned UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that setting Illustrator’s **Run Interval** to **0** disables automatic runs while keeping manual **Illustrate** and **Background** actions available.
  - Documented that the default **Run Interval** remains **5** and requires no Illustrator package update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->