### PR TITLE
test(long-term-memory): clarify test-layer ownership and fix mobile regression

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -73,6 +73,47 @@ MARINARA_ENGINE_ROOT="$PWD" MARINARA_VISUAL_OUTPUT_DIR=/tmp/marinara-visuals \
   "$PWD/../Marinara-Agents/tests/long-term-memory-lifecycle.regression.ts"
 ```
 
+## Long-Term Memory test ownership
+
+Choose the narrowest layer that exercises a contract. Similar assertions at
+different boundaries are not duplicates: remove one only when the surviving
+check exercises the same inputs and cannot pass while the removed check fails.
+
+| Layer | Owning suites (`long-term-memory-*.regression.*`) | Contracts |
+| --- | --- | --- |
+| Direct services | `storage`, `runtime`, `extraction-graph`, `extraction-reliability`, `conversation-summary-import` | Storage recovery/quarantine, lineage-safe retraction, draft dependencies, activity persistence, retrieval lanes and scope, receipt idempotency/redaction, extraction graph validation, identity/dedup boundaries, import invariants |
+| Focused helpers | `index-keys`, `local-characters`, `scope-targets`, `scope-fallback-labels`, `source-task`, `debug-log` | Unsafe keys, local identity isolation, scope selection/labels, task cancellation, debug persistence |
+| HTTP integration | `routes-notes`, `routes-imports`, `routes-drafts`, `routes-scope-identity`, `routes-backup`, and the direct `routes` scenario | Auth/permissions, validation, statuses and client-consumed errors, request-to-service and response-to-persistence mapping, scope translation, applied mutation IDs, preflight, cancellation, backup semantics |
+| Browser | `browser`, `loading`, `feedback-clarity-ui` | Visible workflows, request construction, response consumption, archive undo/partial failure, review/re-extraction, activation, loading and layout; retain explicit static contracts where behavioral proof is absent |
+| Installation | `installation` | Exact ZIP install, offline restart, full-backup inclusion, uninstall/reinstall and durable-byte preservation; `lifecycle` runs browser plus installation |
+| Repository integrity | `node scripts/validate-catalog.mjs` | Manifest-derived lanes and legacy alias, catalog/manifest agreement, artifact URLs, hashes, sizes, archive contents and package contracts |
+
+The split route entrypoints share `long-term-memory-routes.regression.ts` but
+run in separate processes. Its direct `all` scenario also contains unique
+checks; do not remove it as a redundant aggregator. Browser API responses are
+fixtures, not proof of server behavior, and direct source tests do not prove
+that the committed ZIP works. Run the repository baseline as well as LTM tests.
+
+### Cross-layer deletion evidence
+
+Phase 5 (#767) removes only `assertCatalogArtifact()` and its call from the
+browser suite. At baseline `31b391346905318c3b58cf4e4c9990ae5afaaf11`, this
+block was at `long-term-memory-browser.regression.ts:50-68,137`.
+
+| Removed check | Surviving check in `scripts/validate-catalog.mjs` | Why it cannot fail independently on the same repository inputs |
+| --- | --- | --- |
+| LTM entry in v2/v3 and the legacy catalog | Manifest-derived lane equality and legacy alias (109-121), exact downloadable ID set (834-840) | Missing entries fail lane equality or the official package ID check; the current LTM manifest selects v2 and v3. |
+| Catalog version equals package version | Full source-manifest equality (572-575) | Version is part of the compared manifest; divergent lane entries also fail equality. |
+| Official artifact URL | `expectedArtifactUrl` comparison (540-544) | It compares the same package ID/version-derived URL. |
+| Artifact SHA-256 and byte count | Archive size and checksum comparisons (576-585) | Both read the same versioned ZIP and compare the same SHA-256 and byte count. |
+
+These checks read committed files, not browser state. Keep the browser's own
+artifact identity guards and actual client interactions, and keep installation
+durability checks unchanged. No route/service mapping or user-visible assertion
+is removed: cancellation, schema limits, persisted/response/draft/mutation
+scopes, applied mutation IDs, backup/preflight payloads, and browser request
+payloads can fail independently at their respective boundaries.
+
 ## Exact-artifact lifecycle regression
 
 `hierarchical-maps-lifecycle.regression.ts` installs an immutable prior Maps

--- a/tests/long-term-memory-browser.regression.ts
+++ b/tests/long-term-memory-browser.regression.ts
@@ -2271,12 +2271,12 @@ async function main() {
       assert.match(await healthInfoPanel.innerText(), /Check Settings > Maintenance > Reindex recall data\./u);
 
       const showWorkspacePane = async (pane: "navigator" | "workbench" | "inspector") => {
-        const tab = page.locator(`[data-ltm-workspace-pane-tab="${pane}"]`);
-        if ((await tab.count()) === 0) return;
-        // The pane tab may be rendered inside a CSS-hidden switcher (wider layouts show every pane as a
-        // column and hide the tab rail). Dispatch the click handler directly so the active pane still
-        // switches, keeping the flow working in both the narrow tabbed and wider column layouts.
-        await tab.evaluate((element) => (element as HTMLElement).click());
+        const target = page.locator(`[data-ltm-workspace-pane="${pane}"]`);
+        if (!(await target.isVisible())) {
+          // ResizeObserver renders the mobile tabs asynchronously after a viewport change.
+          await page.locator(`[data-ltm-workspace-pane-tab="${pane}"]`).click();
+        }
+        await target.waitFor({ state: "visible" });
       };
       const missingSources = ["source_deleted", "source_vanished"];
       for (const [index, sourceNoteId] of missingSources.entries()) {
@@ -3333,6 +3333,9 @@ async function main() {
       assert.ok(mobileListScrollable.scrollHeight > mobileListScrollable.clientHeight);
       assert.match(mobileListScrollable.overflowY, /auto|scroll/u);
       assert.equal(mobileListScrollable.pageLocked, false);
+      await mobileDestinationList.evaluate((element) => {
+        element.scrollTop = 0;
+      });
       await mobileDestinationList.hover();
       await page.mouse.wheel(0, 600);
       await page.waitForFunction(

--- a/tests/long-term-memory-browser.regression.ts
+++ b/tests/long-term-memory-browser.regression.ts
@@ -47,25 +47,6 @@ process.env.NODE_ENV = "test";
 function sha256(value: Buffer) {
   return createHash("sha256").update(value).digest("hex");
 }
-function assertCatalogArtifact() {
-  for (const relativePath of ["catalog/catalog.json", "catalog/v2/catalog.json", "catalog/v3/catalog.json"]) {
-    const catalog = JSON.parse(readFileSync(join(repoRoot, relativePath), "utf8")) as {
-      packages: Array<{
-        manifest?: { id?: string; version?: string };
-        artifact?: { url?: string; sha256?: string; bytes?: number };
-      }>;
-    };
-    const entry = catalog.packages.find((item) => item.manifest?.id === "long-term-memory");
-    assert.ok(entry, `${relativePath} must contain Long-Term Memory`);
-    assert.equal(entry.manifest?.version, packageManifest.version);
-    assert.equal(
-      entry.artifact?.url,
-      `https://raw.githubusercontent.com/Pasta-Devs/Marinara-Agents/main/artifacts/long-term-memory-${packageManifest.version}.zip`,
-    );
-    assert.equal(entry.artifact?.sha256, sha256(artifactBytes));
-    assert.equal(entry.artifact?.bytes, artifactBytes.byteLength);
-  }
-}
 function catalog() {
   return {
     schemaVersion: 1,
@@ -134,7 +115,6 @@ async function main() {
     async () => {
       assert.equal(artifactManifest.id, "long-term-memory");
       assert.equal(artifactManifest.version, packageManifest.version);
-      assertCatalogArtifact();
       assert.match(
         String(artifactManifest.description),
         /Chat Settings → Agents → Long-Term Memory/u,


### PR DESCRIPTION
# Pull request

> [!IMPORTANT]
> Contributions target `staging`. Only `SpicyMarinara` may promote this repository's `staging` branch to `main`.
> Outside and first-time contributors also require an approving review from `SpicyMarinara`.

<!-- Open as a draft while implementation is in progress. Mark Ready for review only after validation and self-review. -->

## Linked issue

Closes #767

## Why this change

- Phase 5 documents ownership across the Long-Term Memory test layers and removes only catalog assertions already enforced by repository integrity validation. It also fixes a resize race that made the browser suite unable to select the mobile inspector pane reliably.

## What changed

- Added a test ownership matrix and cross-layer deletion evidence to `tests/README.md`.
- Removed the browser fixture's duplicate catalog URL/version/hash/size helper; archive identity and browser behavior checks remain.
- Made the browser pane helper wait for a hidden mobile pane's asynchronously rendered tab and confirm visibility after selection.
- Reset the destination list before the mobile wheel assertion so desktop scroll state cannot satisfy mobile proof.
- No package payload, manifest, artifact, catalog, Engine source, dependency, or CI changes.

## Package and security impact

- Affected package IDs: `long-term-memory` test coverage only.
- Engine compatibility impact: None.
- New or changed permissions/entrypoints: None.
- Restart, storage, update, or uninstall impact: None; existing installation durability coverage remains unchanged.

## Validation

<!-- These are human tasks. Never tick a box for a check that was not actually performed. -->

- [ ] `node scripts/validate-catalog.mjs` passes locally
- [ ] `git diff --check` passes locally
- [ ] Rebuilt every affected manifest, payload, artifact, and catalog entry
- [ ] Installed or updated the affected package through Marinara Engine
- [ ] Checked supported modes, restart behavior, and uninstall cleanup
- [ ] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `test-ci.sh` passed on the final source state, including formatting, lint, catalog/archive/hash validation, locale checks, security regressions, gate tests, and `git diff --check`.
- Isolated `test-ltm.sh all` passed with every LTM suite and the completion watchdog.
- The browser regression passed four consecutive times, including the mobile destination-list bounded-scroll assertion.
- Installation coverage passed for exact ZIP install, offline restart, backup inclusion, uninstall/reinstall, and durable-byte preservation.
- No hosted CI, manual verification, or release-readiness claim is made here. The PR remains a draft pending maintainer review and required gates.

## Documentation impact

- [ ] No documentation changes needed
- [ ] Updated this README catalog and package guidance
- [ ] Updated linked Marinara Engine documentation

## UI evidence (if applicable)

<!-- Add before/after screenshots or recordings for package UI changes. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for maintaining and reviewing long-term memory test coverage across service, browser, installation, and repository-integrity scenarios.
  * Documented how cross-layer evidence supports removing redundant checks while preserving independent coverage.

* **Tests**
  * Improved regression test reliability when switching workspace panes and scrolling mobile destination lists.
  * Retained coverage for browser behavior, installation flows, routing, services, and user-visible outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->