### PR TITLE
fix: improve Long-Term Memory scope picker

### DIFF
--- a/packages/long-term-memory/src/engine/packages/client/src/features/long-term-memory/MemorySettings.tsx
+++ b/packages/long-term-memory/src/engine/packages/client/src/features/long-term-memory/MemorySettings.tsx
@@ -399,6 +399,7 @@ export default function MemorySettings({
         queryKeys.notes,
         queryKeys.activity,
         queryKeys.localCharactersRoot,
+        queryKeys.scopeTargetsRoot,
         ...(props.chatId ? [queryKeys.lastInjection(props.chatId)] : []),
       ]);
     } catch (error) {
@@ -568,6 +569,7 @@ export default function MemorySettings({
         queryKeys.rejectedSuggestions,
         queryKeys.activity,
         queryKeys.localCharactersRoot,
+        queryKeys.scopeTargetsRoot,
         ...(props.chatId ? [queryKeys.lastInjection(props.chatId)] : []),
       ]);
     } catch (error) {

--- a/packages/long-term-memory/src/engine/packages/client/src/features/long-term-memory/MemoryVault.tsx
+++ b/packages/long-term-memory/src/engine/packages/client/src/features/long-term-memory/MemoryVault.tsx
@@ -483,13 +483,15 @@ function ScopeTargetPicker({
         {targetsWithoutMemories.length ? (
           <details
             open={noMemoriesOpen}
-            onToggle={(event) => {
-              if (!wasSearching.current) noMemoriesPreference.current = event.currentTarget.open;
-              setNoMemoriesOpen(event.currentTarget.open);
-            }}
+            onToggle={(event) => setNoMemoriesOpen(event.currentTarget.open)}
             data-ltm-vault-scope-presence="no-memories"
           >
-            <summary className="flex min-h-11 cursor-pointer list-none items-center border-b border-[var(--border)] px-3 py-2 text-xs font-semibold uppercase tracking-wide text-[var(--muted-foreground)] [&::-webkit-details-marker]:hidden">
+            <summary
+              onClick={() => {
+                noMemoriesPreference.current = !noMemoriesOpen;
+              }}
+              className="flex min-h-11 cursor-pointer list-none items-center border-b border-[var(--border)] px-3 py-2 text-xs font-semibold uppercase tracking-wide text-[var(--muted-foreground)] [&::-webkit-details-marker]:hidden"
+            >
               {localizeUi("ui.longTermMemory.memoryvault.noMemories")}
             </summary>
             {targetsWithoutMemories.map(renderRegularTarget)}

--- a/packages/long-term-memory/src/engine/packages/client/src/features/long-term-memory/MemoryVault.tsx
+++ b/packages/long-term-memory/src/engine/packages/client/src/features/long-term-memory/MemoryVault.tsx
@@ -25,6 +25,7 @@ import {
   getLtmScopeChatIds,
   getLtmScopeGroupIds,
   getLtmScopePersonaIds,
+  ltmScopesOverlap,
   normalizeLtmScope,
 } from "../../../../shared/src/features/agents/long-term-memory/scope.js";
 import { invalidateLtmQueries, ltmScopeTargetsKey, queryKeys, request, requestAllNotes } from "./api";
@@ -144,7 +145,17 @@ const prefixes: Record<LtmNoteType, string> = {
   tone: "tone",
 };
 
-type Target = { id: string; label: string; scope?: LtmScope };
+type Target = { id: string; label: string; scope?: LtmScope; comment?: string; chatName?: string | null };
+function targetDisplayLabel(target: Target | null | undefined) {
+  if (!target) return "";
+  const comment = target.comment?.trim();
+  if (comment) return `${target.label} - ${comment}`;
+  return target.chatName?.trim() ? `${target.chatName.trim()} - ${target.label}` : target.label;
+}
+type VaultScopeTargets = Omit<ScopeTargets, "chats"> & {
+  chats: Array<ScopeTargets["chats"][number] & { chatName?: string | null }>;
+  memoryPresence?: LtmScope[] | null;
+};
 type AvailabilityTargets = {
   characters: AvailabilityTarget[];
   personas: AvailabilityTarget[];
@@ -191,6 +202,7 @@ function ScopeTargetPicker({
   targets,
   selectedId,
   currentIds,
+  scopeTargets,
   localizeUi,
   onSelect,
 }: {
@@ -203,6 +215,7 @@ function ScopeTargetPicker({
   };
   selectedId: string;
   currentIds: { chat?: string; branch?: string; character?: string; persona?: string };
+  scopeTargets?: VaultScopeTargets;
   localizeUi: LtmTranslationFunction;
   onSelect: (target: Target) => void;
 }) {
@@ -233,18 +246,110 @@ function ScopeTargetPicker({
             ? targets.character
             : targets.persona;
   const needle = query.trim().toLocaleLowerCase();
-  const filtered = activeTargets.filter((target) => target.label.toLocaleLowerCase().includes(needle));
+  const targetKind = (target: Target, kind: (typeof categories)[number][0]) => {
+    if (kind !== "all") return kind;
+    if (targets.branch.some((candidate) => candidate.id === target.id)) return "branch" as const;
+    if (targets.chat.some((candidate) => candidate.id === target.id)) return "chat" as const;
+    if (targets.character.some((candidate) => candidate.id === target.id)) return "character" as const;
+    return "persona" as const;
+  };
+  const targetFullName = (target: Target, kind: (typeof categories)[number][0]) => {
+    const resolvedKind = targetKind(target, kind);
+    const comment = target.comment?.trim();
+    if (resolvedKind === "branch") {
+      const chat = scopeTargets?.chats.find((candidate) => candidate.id === target.scope?.chatIds?.[0]);
+      const chatName = target.chatName?.trim() || chat?.chatName?.trim();
+      return chatName ? `${chatName} - ${target.label}` : target.label;
+    }
+    return resolvedKind === "persona" && comment ? `${target.label} - ${comment}` : target.label;
+  };
+  const targetSearchText = (target: Target, kind: (typeof categories)[number][0]) =>
+    `${targetFullName(target, kind)} ${target.label} ${target.comment ?? ""}`.toLocaleLowerCase();
+  const filteredTargets = activeTargets.filter((target) => targetSearchText(target, activeKind).includes(needle));
   const pickerId = useId();
   const currentTarget =
     activeKind === "all" ? undefined : activeTargets.find((target) => target.id === currentIds[activeKind]);
-  const displayedTargets = filtered.filter((target) => target.id !== currentTarget?.id);
+  const displayedTargets = filteredTargets.filter((target) => target.id !== currentTarget?.id);
   const options = [
-    { key: "all", target: targets.all, label: localizeUi("ui.longTermMemory.sourcesworkspace.all") },
+    {
+      key: "all",
+      target: targets.all,
+      label: localizeUi("ui.longTermMemory.sourcesworkspace.all"),
+      kind: "all" as const,
+    },
     ...(activeKind === "all"
       ? []
-      : [{ key: "current", target: currentTarget, label: localizeUi("ui.longTermMemory.memoryvault.current") }]),
-    ...displayedTargets.map((target) => ({ key: target.id, target, label: target.label })),
+      : [
+          {
+            key: "current",
+            target: currentTarget,
+            label: localizeUi("ui.longTermMemory.memoryvault.current"),
+            kind: activeKind,
+          },
+        ]),
   ];
+  const regularTargets = displayedTargets;
+  const hasMemoryPresence = scopeTargets?.memoryPresence !== undefined && scopeTargets.memoryPresence !== null;
+  const targetsWithMemories = hasMemoryPresence
+    ? regularTargets.filter((target) =>
+        scopeTargets?.memoryPresence?.some((scope) => ltmScopesOverlap(scope, target.scope, { includeGlobal: false })),
+      )
+    : [];
+  const targetsWithoutMemories = hasMemoryPresence
+    ? regularTargets.filter(
+        (target) =>
+          !scopeTargets?.memoryPresence?.some((scope) =>
+            ltmScopesOverlap(scope, target.scope, { includeGlobal: false }),
+          ),
+      )
+    : [];
+  const neutralTargets = hasMemoryPresence ? [] : regularTargets;
+  const [noMemoriesOpen, setNoMemoriesOpen] = useState(false);
+  const noMemoriesPreference = useRef(false);
+  const wasSearching = useRef(false);
+  useEffect(() => {
+    if (needle) setNoMemoriesOpen(true);
+    else if (wasSearching.current) setNoMemoriesOpen(noMemoriesPreference.current);
+    wasSearching.current = Boolean(needle);
+  }, [needle]);
+  const renderRegularTarget = (target: Target) => {
+    const fullName = targetFullName(target, activeKind);
+    const branchChatName =
+      targetKind(target, activeKind) === "branch"
+        ? target.chatName?.trim() ||
+          scopeTargets?.chats.find((candidate) => candidate.id === target.scope?.chatIds?.[0])?.chatName?.trim()
+        : undefined;
+    return (
+      <button
+        key={target.id}
+        type="button"
+        data-ltm-vault-scope-target={target.id}
+        title={fullName}
+        role="checkbox"
+        aria-checked={target.id === selectedId}
+        data-selected={target.id === selectedId ? "true" : "false"}
+        className="mari-editor-action flex min-h-11 w-full min-w-0 items-center gap-3 rounded-none border-x-0 border-t-0 px-3 py-2 text-left text-sm last:border-b-0 data-[selected=true]:bg-[var(--primary)]/10"
+        onClick={() => onSelect(target)}
+      >
+        <Check
+          aria-hidden="true"
+          size="0.875rem"
+          className={target.id === selectedId ? "shrink-0 text-[var(--marinara-editor-accent)]" : "shrink-0 opacity-0"}
+        />
+        <span className="flex min-w-0 flex-1">
+          {branchChatName ? (
+            <>
+              <span className="min-w-0 flex-1 truncate">{branchChatName}</span>
+              <span className="shrink-0"> - </span>
+              <span className="min-w-0 max-w-full shrink truncate">{target.label}</span>
+            </>
+          ) : (
+            <span className="min-w-0 flex-1 truncate">{fullName}</span>
+          )}
+        </span>
+      </button>
+    );
+  };
   return (
     <div
       id="ltm-vault-scope-control"
@@ -332,8 +437,9 @@ function ScopeTargetPicker({
         aria-labelledby={`${pickerId}-${activeKind}`}
         className="min-w-0 max-h-52 overflow-y-auto overscroll-contain divide-y divide-[var(--border)] border-y border-[var(--border)]"
       >
-        {options.map(({ key, target: optionTarget, label }) => {
+        {options.map(({ key, target: optionTarget, label, kind }) => {
           const selected = optionTarget?.id === selectedId;
+          const fullName = optionTarget ? targetFullName(optionTarget, kind) : label;
           return (
             <button
               key={key}
@@ -342,7 +448,7 @@ function ScopeTargetPicker({
               data-ltm-vault-scope-current={key === "current" ? activeKind : undefined}
               data-ltm-vault-scope-pinned={key === "all" || key === "current" ? key : undefined}
               disabled={!optionTarget}
-              title={optionTarget?.label}
+              title={key === "all" ? optionTarget?.label : fullName}
               role="checkbox"
               aria-checked={selected}
               data-selected={selected ? "true" : "false"}
@@ -355,7 +461,7 @@ function ScopeTargetPicker({
                 className={selected ? "shrink-0 text-[var(--marinara-editor-accent)]" : "shrink-0 opacity-0"}
               />
               <span className="min-w-0 flex-1 truncate">
-                {label}
+                {key === "all" ? label : fullName}
                 {key === "current" && optionTarget ? (
                   <span className="block truncate text-xs text-[var(--marinara-editor-muted)]">
                     {optionTarget.label}
@@ -365,7 +471,31 @@ function ScopeTargetPicker({
             </button>
           );
         })}
-        {!filtered.length && activeKind !== "all" ? (
+        {neutralTargets.map(renderRegularTarget)}
+        {targetsWithMemories.length ? (
+          <div data-ltm-vault-scope-presence="with-memories">
+            <p className="border-b border-[var(--border)] bg-[var(--secondary)] px-3 py-1 text-xs font-semibold uppercase tracking-wide text-[var(--muted-foreground)]">
+              {localizeUi("ui.longTermMemory.memoryvault.withMemories")}
+            </p>
+            {targetsWithMemories.map(renderRegularTarget)}
+          </div>
+        ) : null}
+        {targetsWithoutMemories.length ? (
+          <details
+            open={noMemoriesOpen}
+            onToggle={(event) => {
+              if (!wasSearching.current) noMemoriesPreference.current = event.currentTarget.open;
+              setNoMemoriesOpen(event.currentTarget.open);
+            }}
+            data-ltm-vault-scope-presence="no-memories"
+          >
+            <summary className="flex min-h-11 cursor-pointer list-none items-center border-b border-[var(--border)] px-3 py-2 text-xs font-semibold uppercase tracking-wide text-[var(--muted-foreground)] [&::-webkit-details-marker]:hidden">
+              {localizeUi("ui.longTermMemory.memoryvault.noMemories")}
+            </summary>
+            {targetsWithoutMemories.map(renderRegularTarget)}
+          </details>
+        ) : null}
+        {!filteredTargets.length && activeKind !== "all" ? (
           <p className="px-3 py-4 text-xs text-[var(--muted-foreground)]">
             {localizeUi("ui.longTermMemory.memoryvault.noScopeTargets")}
           </p>
@@ -1389,7 +1519,7 @@ export default function MemoryVault({
     queryKey: ltmScopeTargetsKey(props.chatId),
     staleTime: 30_000,
     queryFn: () =>
-      request<ScopeTargets>(
+      request<VaultScopeTargets>(
         `/scope-targets?includeAllChats=true${props.chatId ? `&chatId=${encodeURIComponent(props.chatId)}` : ""}`,
       ),
   });
@@ -1572,6 +1702,7 @@ export default function MemoryVault({
     ...(scopeTargets.data?.chats ?? []).map((chat) => ({
       id: `chat:${chat.id}`,
       label: chat.label,
+      chatName: chat.chatName,
       scope: { chatId: chat.id, chatIds: [chat.id] },
     })),
     ...(scopeTargets.data?.groups ?? []).map((group) => ({
@@ -1589,6 +1720,7 @@ export default function MemoryVault({
     ...(scopeTargets.data?.personas ?? []).map((persona) => ({
       id: `persona:${persona.id}`,
       label: persona.label,
+      comment: persona.comment,
       scope: { personaId: persona.id },
     })),
   ].filter((candidate, index, items) => items.findIndex((item) => item.id === candidate.id) === index);
@@ -1673,6 +1805,7 @@ export default function MemoryVault({
   const branchScopeTargets = branches.map((branch) => ({
     id: `chat:${branch.id}`,
     label: branch.label,
+    chatName: scopeTargets.data?.chats.find((chat) => chat.id === branch.id)?.chatName,
     scope: {
       chatId: branch.id,
       chatIds: [branch.id],
@@ -1687,6 +1820,7 @@ export default function MemoryVault({
           branchScopeTargets.find((candidate) => candidate.id === `chat:${currentChat.id}`)?.label ??
           props.chatName ??
           localizeUi("ui.longTermMemory.memoryvault.currentChat"),
+        chatName: scopeTargets.data?.chats.find((chat) => chat.id === currentChat.id)?.chatName,
         scope: scopeTargets.data?.currentScope ?? { chatId: currentChat.id, chatIds: [currentChat.id] },
       }
     : null;
@@ -2055,6 +2189,7 @@ export default function MemoryVault({
       queryKeys.integrity,
       queryKeys.lastInjectionRoot,
       queryKeys.localCharactersRoot,
+      queryKeys.scopeTargetsRoot,
     ]);
   }
   async function undoArchive(recovery: ArchiveUndoState) {
@@ -2253,6 +2388,7 @@ export default function MemoryVault({
           queryKeys.status,
           queryKeys.activity,
           queryKeys.localCharactersRoot,
+          queryKeys.scopeTargetsRoot,
         ]).catch(() => {});
         return false;
       }
@@ -2303,6 +2439,7 @@ export default function MemoryVault({
         queryKeys.status,
         queryKeys.activity,
         queryKeys.localCharactersRoot,
+        queryKeys.scopeTargetsRoot,
         ...(rejectedId && recoveryComplete ? [queryKeys.rejectedSuggestions] : []),
       ]).catch(() => {});
       succeeded = savedCurrentDraft;
@@ -2823,7 +2960,7 @@ export default function MemoryVault({
                         {localizeUi("ui.longTermMemory.memoryvault.currentlyViewingMemoriesIn")}
                       </span>
                       <span className="block truncate text-xs font-semibold text-[var(--marinara-editor-text)]">
-                        {target?.label ?? localizeUi("ui.longTermMemory.memoryvault.allMemories")}
+                        {targetDisplayLabel(target) || localizeUi("ui.longTermMemory.memoryvault.allMemories")}
                       </span>
                     </span>
                     <ChevronRight
@@ -2843,6 +2980,7 @@ export default function MemoryVault({
                         persona: (scopeTargets.data?.personas ?? []).map((persona) => ({
                           id: `persona:${persona.id}`,
                           label: persona.label,
+                          comment: persona.comment,
                           scope: { personaId: persona.id },
                         })),
                       }}
@@ -2853,6 +2991,7 @@ export default function MemoryVault({
                         character: currentCharacterTarget?.id,
                         persona: currentChat?.personaId ? `persona:${currentChat.personaId}` : undefined,
                       }}
+                      scopeTargets={scopeTargets.data}
                       localizeUi={localizeUi}
                       onSelect={(candidate) => void selectTarget(candidate)}
                     />

--- a/packages/long-term-memory/src/engine/packages/client/src/features/long-term-memory/locales/en.json
+++ b/packages/long-term-memory/src/engine/packages/client/src/features/long-term-memory/locales/en.json
@@ -467,6 +467,8 @@
   "ui.longTermMemory.memoryvault.noMatchingCharacters": "No matching characters.",
   "ui.longTermMemory.memoryvault.noMatchingChats": "No matching chats.",
   "ui.longTermMemory.memoryvault.noMatchingPersonas": "No matching personas.",
+  "ui.longTermMemory.memoryvault.withMemories": "With memories",
+  "ui.longTermMemory.memoryvault.noMemories": "No memories",
   "ui.longTermMemory.memoryvault.noSavedMemoriesLinkToThisSourceYet": "No saved memories link to this source yet.",
   "ui.longTermMemory.memoryvault.noSavedMemoriesYetImportASourceOrCreate": "No saved memories yet. Import a character, lorebook, or chat summary and accept its proposals, or create a memory manually.",
   "ui.longTermMemory.memoryvault.noScopeTargets": "No matching places.",

--- a/packages/long-term-memory/src/engine/packages/client/src/features/long-term-memory/scope-targets.ts
+++ b/packages/long-term-memory/src/engine/packages/client/src/features/long-term-memory/scope-targets.ts
@@ -7,6 +7,7 @@ export type ScopeTargetChat = {
   groupId: string | null;
   personaId: string | null;
   characterIds: string[];
+  chatName?: string | null;
 };
 export type ScopeTargetGroup = { id: string; label: string; chatIds: string[] };
 export type ScopeTargetCharacter = {
@@ -32,6 +33,7 @@ export type ScopeTargets = {
   characters: ScopeTargetCharacter[];
   personas: ScopeTargetPersona[];
   localCharacters: ScopeTargetLocalCharacter[];
+  memoryPresence?: LtmScope[] | null;
 };
 export type ScopeIndexes = {
   chatsById: Map<string, ScopeTargetChat>;

--- a/packages/long-term-memory/src/engine/packages/server/src/services/long-term-memory/routes.ts
+++ b/packages/long-term-memory/src/engine/packages/server/src/services/long-term-memory/routes.ts
@@ -45,6 +45,7 @@ import {
   ltmStatusResponseSchema,
   ltmWriteScopeSchema,
   ltmScopeSchema,
+  type LtmScope,
   ltmSectionKeySchema,
   ltmSectionSchema,
   ltmStatusSchema,
@@ -728,6 +729,7 @@ export function createLongTermMemoryRoutes(runtime: {
           .map((chat) => ({
             id: chat.id,
             label: getLtmChatDisplayName(chat) || "Untitled chat",
+            chatName: chat.name?.trim() || "Untitled chat",
             mode: ltmModeForChatMode(chat.mode),
             groupId: chat.groupId,
             personaId: chat.personaId,
@@ -735,6 +737,11 @@ export function createLongTermMemoryRoutes(runtime: {
           }))
           .sort((left, right) => left.label.localeCompare(right.label) || left.id.localeCompare(right.id)),
       );
+      const memoryPresence: LtmScope[] = [];
+      for (const note of notes) {
+        if (note.type === "source") continue;
+        memoryPresence.push(note.scope);
+      }
       const resourceById = new Map(eligibleResources.map((resource) => [resource.id, resource]));
       const visibleCharacterIds = includeAllChats
         ? new Set(eligibleResources.map((resource) => resource.id))
@@ -755,6 +762,7 @@ export function createLongTermMemoryRoutes(runtime: {
       );
       return {
         currentScope: currentChat ? resolveChatLtmScope(currentChat) : null,
+        memoryPresence,
         chats: namedChats,
         groups: numberDuplicateLabels(
           [...groupIds]

--- a/tests/long-term-memory-browser.regression.ts
+++ b/tests/long-term-memory-browser.regression.ts
@@ -1669,10 +1669,6 @@ async function main() {
       );
       await memoryScope.locator("[data-ltm-vault-scope-search]").fill("");
       assert.ok(await memoryScope.locator('[data-ltm-vault-scope-current="branch"]').isDisabled());
-      assert.equal(
-        await memoryScope.locator('[data-ltm-vault-scope-current="branch"]').locator("span").nth(1).innerText(),
-        "Member Final Branch",
-      );
       await memoryScope.locator('[data-ltm-vault-scope-tab="chat"]').click();
       assert.equal(
         await memoryScope.locator('[data-ltm-vault-scope-current="chat"]').getAttribute("data-ltm-vault-scope-target"),

--- a/tests/long-term-memory-browser.regression.ts
+++ b/tests/long-term-memory-browser.regression.ts
@@ -717,6 +717,7 @@ async function main() {
           scopeTargetQueries.push(url.search);
           return send(200, {
             currentScope: { chatId: "desktop-chat", chatIds: ["desktop-chat"] },
+            memoryPresence: [{ chatId: "memory-chat", chatIds: ["memory-chat"] }],
             chats: [
               {
                 id: "desktop-chat",
@@ -729,6 +730,7 @@ async function main() {
               {
                 id: "memory-chat",
                 label: "Member Final Branch",
+                chatName: "Memory Conversation",
                 mode: "roleplay",
                 groupId: "conversation-a",
                 personaId: "persona-a",
@@ -737,6 +739,7 @@ async function main() {
               {
                 id: "memory-conversation-branch",
                 label: "Memory conversation branch",
+                chatName: "Memory Conversation",
                 mode: "conversation",
                 groupId: "conversation-a",
                 personaId: "persona-a",
@@ -1642,7 +1645,34 @@ async function main() {
         1,
       );
       await memoryScope.locator('[data-ltm-vault-scope-tab="branch"]').click();
+      assert.equal(await memoryScope.locator('[data-ltm-vault-scope-presence="with-memories"]').count(), 1);
+      assert.equal(await memoryScope.locator('[data-ltm-vault-scope-presence="no-memories"]').count(), 1);
+      assert.equal(
+        await memoryScope.locator('[data-ltm-vault-scope-presence="no-memories"]').getAttribute("open"),
+        null,
+      );
+      assert.equal(
+        await memoryScope.locator('[data-ltm-vault-scope-target="chat:memory-chat"]').getAttribute("title"),
+        "Memory Conversation - Member Final Branch",
+      );
+      await memoryScope.locator("[data-ltm-vault-scope-search]").fill("Memory Conversation");
+      assert.equal(
+        await memoryScope.locator('[data-ltm-vault-scope-presence="no-memories"]').evaluate((element) => element.open),
+        true,
+      );
+      await memoryScope.locator('[data-ltm-vault-scope-presence="no-memories"] > summary').click();
+      await memoryScope.locator("[data-ltm-vault-scope-search]").fill("");
+      await memoryScope.locator("[data-ltm-vault-scope-search]").fill("Memory Conversation");
+      assert.equal(
+        await memoryScope.locator('[data-ltm-vault-scope-presence="no-memories"]').evaluate((element) => element.open),
+        false,
+      );
+      await memoryScope.locator("[data-ltm-vault-scope-search]").fill("");
       assert.ok(await memoryScope.locator('[data-ltm-vault-scope-current="branch"]').isDisabled());
+      assert.equal(
+        await memoryScope.locator('[data-ltm-vault-scope-current="branch"]').locator("span").nth(1).innerText(),
+        "Member Final Branch",
+      );
       await memoryScope.locator('[data-ltm-vault-scope-tab="chat"]').click();
       assert.equal(
         await memoryScope.locator('[data-ltm-vault-scope-current="chat"]').getAttribute("data-ltm-vault-scope-target"),


### PR DESCRIPTION
## Linked issue

Closes #811

## Why this change

- Make Memory Vault scopes easier to identify and distinguish populated scopes from empty ones.

## What changed

- Affected package: `long-term-memory`.
- Branch rows display the associated chat name and branch name, with responsive truncation.
- Persona rows include their short comments when present.
- Scope rows are grouped into “With memories” and a collapsed “No memories” section. Search temporarily opens matching empty scopes and restores the manual state afterward.
- `/scope-targets` supplies memory-presence metadata derived from the existing note snapshot.
- Scope-target caches refresh after relevant memory mutations and repairs.
- Added focused browser regression coverage.

## Package and security impact

- Affected package IDs: `long-term-memory`
- Engine compatibility impact: No selection, scope, recall, or request-parameter changes.
- New or changed permissions/entrypoints: None.
- Restart, storage, update, or uninstall impact: None.

## Validation

- [ ] `node scripts/validate-catalog.mjs` passes locally
- [x] `git diff --check` passes locally
- [ ] Rebuilt every affected manifest, payload, artifact, and catalog entry
- [ ] Installed or updated the affected package through Marinara Engine
- [ ] Checked supported modes, restart behavior, and uninstall cleanup
- [x] Read and followed `CONTRIBUTING.md`

### Manual verification notes

- `npm ci` passed.
- `npm run check` passed with 0 errors and existing warnings.
- `npx tsx tests/long-term-memory-scope-targets.regression.ts` passed.
- Package typecheck is blocked by the pre-existing `retention.ts:169` logger error.
- Package rebuild is blocked because the neighboring Engine checkout lacks `esbuild/bin/esbuild`.
- Full `test-ci.sh` and LTM lifecycle validation were unavailable in this environment.

## Documentation impact

- [x] No documentation changes needed
- [ ] Updated this README catalog and package guidance
- [ ] Updated linked Marinara Engine documentation

## UI evidence (if applicable)

- Focused browser regression assertions cover labels, grouping, collapse/search restoration, and current-row behavior. Visual screenshots were not captured because the package rebuild/lifecycle environment was unavailable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scope target picker now shows chat names and persona comments for clearer identification.
  * Targets can be searched using combined names and labels.
  * Branches are grouped by whether they contain memories, with empty groups collapsed by default.
  * Matching searches automatically expand relevant groups.
* **Bug Fixes**
  * Memory and identity maintenance now refreshes scope target data immediately.
  * Scope target updates consistently refresh across the memory vault.
* **Tests**
  * Added coverage for memory-status grouping, search behavior, and chat-name display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->